### PR TITLE
Update Compose libraries to latest stable versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
             use_local_pumpx2 = (properties.getProperty('use_local_pumpx2') ?: '') == 'true'
         }
         m2_repository = "${System.properties['user.home']}/.m2/repository"
-        compose_version = '1.7.8'
+        compose_bom_version = '2025.09.00'
         androidx_watchface_version = '1.2.1'
         kotlin_version = "2.1.10"
     }

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -66,11 +66,15 @@ paperwork {
 dependencies {
     implementation 'hu.supercluster:paperwork:1.2.7'
 
-    implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.7.0'
-    implementation 'com.google.android.gms:play-services-wearable:18.0.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation platform("androidx.compose:compose-bom:${project.compose_bom_version}")
+    androidTestImplementation platform("androidx.compose:compose-bom:${project.compose_bom_version}")
+    debugImplementation platform("androidx.compose:compose-bom:${project.compose_bom_version}")
+
+    implementation 'androidx.core:core-ktx:1.17.0'
+    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation 'com.google.android.material:material:1.13.0'
+    implementation 'com.google.android.gms:play-services-wearable:19.0.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'com.android.volley:volley:1.2.1'
 
     implementation project(path: ':shared')
@@ -82,7 +86,7 @@ dependencies {
     implementation "commons-codec:commons-codec:1.18.0"
     implementation "org.apache.commons:commons-lang3:3.17.0"
     implementation "com.google.guava:guava:33.3.1-android"
-    implementation 'org.bouncycastle:bcprov-jdk14:1.77'
+    implementation 'org.bouncycastle:bcprov-jdk14:1.82'
 
     // pumpx2
     if (project.use_local_pumpx2) {
@@ -95,21 +99,21 @@ dependencies {
         implementation "com.github.jwoglom.pumpX2:pumpx2-shared:v${project.pumpx2_version}"
     }
 
-    var lifecycle_version = '2.8.7'
+    var lifecycle_version = '2.9.4'
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
-    implementation 'androidx.activity:activity-compose:1.10.1'
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    var material3_version = '1.3.1'
-    implementation "androidx.compose.material3:material3:$material3_version"
-    implementation "androidx.compose.material3:material3-android:$material3_version"
-    implementation 'androidx.navigation:navigation-compose:2.8.8'
-    implementation 'androidx.navigation:navigation-runtime-ktx:2.8.8'
-    implementation 'androidx.compose.material:material:1.7.8'
-    implementation 'androidx.compose.runtime:runtime-livedata:1.7.8'
+    implementation 'androidx.activity:activity-compose:1.11.0'
+    implementation 'androidx.compose.ui:ui'
+    implementation 'androidx.compose.ui:ui-tooling'
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    implementation 'androidx.compose.material3:material3'
+    implementation 'androidx.compose.material3:material3-android'
+    implementation 'androidx.navigation:navigation-compose:2.9.4'
+    implementation 'androidx.navigation:navigation-runtime-ktx:2.9.4'
+    implementation 'androidx.compose.material:material'
+    implementation 'androidx.compose.material:material-icons-extended'
+    implementation 'androidx.compose.runtime:runtime-livedata'
 
 
     // charts
@@ -123,19 +127,19 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
+    androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
+    debugImplementation 'androidx.compose.ui:ui-tooling'
+    debugImplementation 'androidx.compose.ui:ui-test-manifest'
 
     // room
-    var room_version = "2.6.1"
+    var room_version = "2.8.0"
     implementation("androidx.room:room-runtime:$room_version")
     annotationProcessor("androidx.room:room-compiler:$room_version")
     ksp("androidx.room:room-compiler:$room_version")
     implementation("androidx.room:room-ktx:$room_version")
     implementation("androidx.room:room-guava:$room_version")
     testImplementation("androidx.room:room-testing:$room_version")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
 
     wearApp project(":wear")
 }

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -45,18 +45,21 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.15.0'
-    implementation 'androidx.appcompat:appcompat:1.7.0'
-    implementation 'com.google.android.material:material:1.12.0'
+    implementation platform("androidx.compose:compose-bom:${project.compose_bom_version}")
+    androidTestImplementation platform("androidx.compose:compose-bom:${project.compose_bom_version}")
+
+    implementation 'androidx.core:core-ktx:1.17.0'
+    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation 'com.google.android.material:material:1.13.0'
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 
     // compose
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.8.7'
-    implementation 'androidx.activity:activity-compose:1.10.1'
-    implementation "androidx.compose.ui:ui:$compose_version"
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.9.4'
+    implementation 'androidx.activity:activity-compose:1.11.0'
+    implementation 'androidx.compose.ui:ui'
 
     // pumpx2-android dependencies
     implementation 'com.github.weliem:blessed-android:2.4.0'
@@ -65,7 +68,7 @@ dependencies {
     implementation "commons-codec:commons-codec:1.18.0"
     implementation "org.apache.commons:commons-lang3:3.17.0"
     implementation "com.google.guava:guava:33.3.1-android"
-    implementation 'org.bouncycastle:bcprov-jdk14:1.77'
+    implementation 'org.bouncycastle:bcprov-jdk14:1.82'
 
     // pumpx2
     if (project.use_local_pumpx2) {

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -59,33 +59,38 @@ paperwork {
 dependencies {
     implementation 'hu.supercluster:paperwork:1.2.7'
 
-    implementation 'androidx.core:core-ktx:1.15.0'
+    implementation platform("androidx.compose:compose-bom:${project.compose_bom_version}")
+    androidTestImplementation platform("androidx.compose:compose-bom:${project.compose_bom_version}")
+    debugImplementation platform("androidx.compose:compose-bom:${project.compose_bom_version}")
+
+    implementation 'androidx.core:core-ktx:1.17.0'
     implementation 'com.google.android.gms:play-services-wearable:19.0.0'
     implementation 'androidx.percentlayout:percentlayout:1.0.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
     implementation 'androidx.wear:wear:1.3.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.3'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.2'
 
     // General compose dependencies
-    implementation 'androidx.activity:activity-compose:1.10.1'
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling:$compose_version"
-    implementation 'androidx.compose.foundation:foundation:1.7.8'
-    implementation 'androidx.compose.runtime:runtime-livedata:1.7.8'
+    implementation 'androidx.activity:activity-compose:1.11.0'
+    implementation 'androidx.compose.ui:ui'
+    implementation 'androidx.compose.ui:ui-tooling'
+    implementation 'androidx.compose.foundation:foundation'
+    implementation 'androidx.compose.runtime:runtime-livedata'
     implementation 'androidx.core:core-splashscreen:1.0.1'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7'
-    implementation 'androidx.compose.material:material:1.7.8'
-    implementation 'androidx.compose.material:material-icons-core:1.7.8'
-    implementation 'androidx.compose.material:material-icons-extended:1.7.8'
-    implementation 'androidx.compose.material3:material3:1.3.1'
-    implementation 'androidx.wear.compose:compose-foundation:1.4.1'
-    implementation 'androidx.wear.compose:compose-material:1.4.1'
-    implementation 'androidx.wear.compose:compose-navigation:1.4.1'
-    implementation 'androidx.wear:wear-input:1.2.0-alpha02'
-    implementation 'com.google.android.horologist:horologist-composables:0.2.4'
-    implementation 'com.google.android.horologist:horologist-compose-layout:0.2.4'
-    implementation 'com.google.accompanist:accompanist-flowlayout:0.28.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.9.4'
+    implementation 'androidx.compose.material:material'
+    implementation 'androidx.compose.material:material-icons-core'
+    implementation 'androidx.compose.material:material-icons-extended'
+    implementation 'androidx.compose.material3:material3'
+    implementation 'androidx.compose.material3:material3-android'
+    implementation 'androidx.wear.compose:compose-foundation:1.5.1'
+    implementation 'androidx.wear.compose:compose-material:1.5.1'
+    implementation 'androidx.wear.compose:compose-navigation:1.5.1'
+    implementation 'androidx.wear:wear-input:1.2.0'
+    implementation 'com.google.android.horologist:horologist-composables:0.7.15'
+    implementation 'com.google.android.horologist:horologist-compose-layout:0.7.15'
+    implementation 'com.google.accompanist:accompanist-flowlayout:0.36.0'
 
     // https://issuetracker.google.com/issues/227767363
     debugImplementation "androidx.customview:customview:1.2.0-alpha02"
@@ -98,7 +103,7 @@ dependencies {
     implementation "commons-codec:commons-codec:1.18.0"
     implementation "org.apache.commons:commons-lang3:3.17.0"
     implementation "com.google.guava:guava:33.3.1-android"
-    implementation 'org.bouncycastle:bcprov-jdk14:1.77'
+    implementation 'org.bouncycastle:bcprov-jdk14:1.82'
 
     // pumpx2
     if (project.use_local_pumpx2) {
@@ -115,10 +120,10 @@ dependencies {
 
     // androidx
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
-    implementation 'androidx.navigation:navigation-runtime-ktx:2.8.9'
+    implementation 'androidx.navigation:navigation-runtime-ktx:2.9.4'
     implementation 'androidx.wear:wear-remote-interactions:1.1.0'
-    implementation 'androidx.datastore:datastore-preferences:1.1.3'
-    implementation 'androidx.datastore:datastore-preferences-core:1.1.3'
+    implementation 'androidx.datastore:datastore-preferences:1.1.7'
+    implementation 'androidx.datastore:datastore-preferences-core:1.1.7'
 
     implementation "androidx.wear.watchface:watchface:${project.androidx_watchface_version}"
     implementation "androidx.wear.watchface:watchface-complications-data-source:${project.androidx_watchface_version}"


### PR DESCRIPTION
## Summary
- adopt the Jetpack Compose BOM (2025.09.00) at the project root and use it to manage Compose artifacts across modules
- refresh AndroidX, Room, coroutines, and Material dependencies in the mobile and shared modules to their latest stable releases while adding material-icons extended support
- align the Wear module with current Wear Compose, Horologist, wear-input, Datastore, and security library versions to remove deprecated APIs

## Testing
- `./gradlew clean build` *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdbd65bc8c832cbe9d6320ce9987a9