### PR TITLE
Add Compose preview tooling scaffolding

### DIFF
--- a/.codex/compose-screenshots-plan.md
+++ b/.codex/compose-screenshots-plan.md
@@ -6,6 +6,11 @@
 - Automatically post a PR comment summarizing previews with collapsible sections, one per composable/component, each containing its associated images.
 - Ensure the workflow is reproducible locally so contributors can validate previews prior to pushing changes.
 
+## Current Status
+- ✅ Bootstrapped a `buildSrc` Gradle convention plugin that registers placeholder metadata and rendering tasks, plus aggregate entry points (`collectAllComposePreviewMetadata`, `renderAllComposePreviews`). The plugin is applied to the `mobile` module so contributors can begin invoking the scaffolding; tasks currently emit placeholder JSON/marker files instead of real preview assets.
+- ⬜ Replace the placeholder task implementations with actual Compose preview discovery and rendering.
+- ⬜ Author local helper scripts and CI automation (artifact upload + PR comment).
+
 ## Recommended Technical Approach
 
 ### 1. Render previews off-device using Compose tooling
@@ -89,7 +94,7 @@ If direct usage of `PreviewRenderer` proves brittle, Square's [Paparazzi](https:
 - **Security**: PR comment posting requires `GITHUB_TOKEN` with `pull-requests: write` scope. Ensure the workflow uses the default token and handles forks by running the commenting step only on trusted contexts (e.g., via `if: github.event.pull_request.head.repo.fork == false`).
 
 ## Next Steps
-1. Prototype the Gradle preview renderer locally, starting with the `mobile` module to validate metadata discovery and PNG output.
+1. ✅ Prototype the Gradle preview tooling scaffolding by introducing a `buildSrc` convention plugin for the `mobile` module (placeholder metadata/render tasks + aggregate entry points). Next iteration: replace the placeholders with real metadata discovery and rendering that produces preview assets.
 2. Extend the plugin to handle the `wear` module and generate a consolidated manifest for PR consumption.
 3. Author scripts for Markdown generation and integrate with GitHub Actions as outlined.
 4. Run the preview rendering command locally as proof-of-concept, then open the implementation PR with CI validation.

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    `kotlin-dsl`
+}
+
+kotlin {
+    jvmToolchain(17)
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+dependencies {
+    implementation("com.android.tools.build:gradle-api:8.8.2")
+    compileOnly("com.android.tools.build:gradle:8.8.2")
+}

--- a/buildSrc/src/main/kotlin/CollectComposePreviewsTask.kt
+++ b/buildSrc/src/main/kotlin/CollectComposePreviewsTask.kt
@@ -1,0 +1,45 @@
+package com.jwoglom.controlx2.build.compose
+
+import java.time.Instant
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+abstract class CollectComposePreviewsTask : DefaultTask() {
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @get:Input
+    abstract val variantName: Property<String>
+
+    @get:Input
+    abstract val modulePath: Property<String>
+
+    @TaskAction
+    fun collect() {
+        val output = outputFile.get().asFile
+        output.parentFile.mkdirs()
+
+        val payload = buildString {
+            appendLine("{")
+            appendLine("  \"status\": \"placeholder\",")
+            appendLine("  \"message\": \"Compose preview discovery not yet implemented\",")
+            appendLine("  \"modulePath\": \"${escape(modulePath.get())}\",")
+            appendLine("  \"variant\": \"${escape(variantName.get())}\",")
+            appendLine("  \"generatedAt\": \"${escape(Instant.now().toString())}\"")
+            appendLine("}")
+        }
+
+        output.writeText(payload)
+        logger.lifecycle(
+            "Created placeholder Compose preview metadata for ${modulePath.get()}#${variantName.get()} at ${output.absolutePath}"
+        )
+    }
+
+    private fun escape(input: String): String = input
+        .replace("\\", "\\\\")
+        .replace("\"", "\\\"")
+}

--- a/buildSrc/src/main/kotlin/ComposePreviewPlugin.kt
+++ b/buildSrc/src/main/kotlin/ComposePreviewPlugin.kt
@@ -1,0 +1,116 @@
+package com.jwoglom.controlx2.build.compose
+
+import com.android.build.api.variant.AndroidComponentsExtension
+import java.util.Locale
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.kotlin.dsl.register
+
+class ComposePreviewPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        val rootProject = project.rootProject
+        val aggregateMetadata = ensureAggregateTask(
+            rootProject,
+            key = "controlx2.compose.aggregate.collect",
+            name = "collectAllComposePreviewMetadata",
+            description = "Collects Compose preview metadata across all modules."
+        )
+        val aggregateRender = ensureAggregateTask(
+            rootProject,
+            key = "controlx2.compose.aggregate.render",
+            name = "renderAllComposePreviews",
+            description = "Renders Compose previews across all modules."
+        )
+
+        aggregateRender.configure { dependsOn(aggregateMetadata) }
+
+        project.pluginManager.withPlugin("com.android.application") {
+            configureAndroidVariants(project, aggregateMetadata, aggregateRender)
+        }
+        project.pluginManager.withPlugin("com.android.library") {
+            configureAndroidVariants(project, aggregateMetadata, aggregateRender)
+        }
+    }
+
+    private fun configureAndroidVariants(
+        project: Project,
+        aggregateMetadata: TaskProvider<Task>,
+        aggregateRender: TaskProvider<Task>
+    ) {
+        val androidComponents = project.extensions.findByType(AndroidComponentsExtension::class.java) ?: return
+
+        androidComponents.onVariants(androidComponents.selector().withBuildType("debug")) { variant ->
+            registerVariantTasks(project, variant.name, aggregateMetadata, aggregateRender)
+        }
+    }
+
+    private fun registerVariantTasks(
+        project: Project,
+        variantName: String,
+        aggregateMetadata: TaskProvider<Task>,
+        aggregateRender: TaskProvider<Task>
+    ) {
+        val taskSuffix = variantName.toTaskSuffix()
+
+        val collectTask = project.tasks.register<CollectComposePreviewsTask>(
+            "collectComposePreviewMetadata$taskSuffix"
+        ) {
+            group = TASK_GROUP
+            description = "Collect Compose preview metadata for the $variantName variant of ${project.path}."
+            this.variantName.set(variantName)
+            this.modulePath.set(project.path)
+            outputFile.set(
+                project.layout.buildDirectory.file("composePreviews/$variantName/metadata.json")
+            )
+        }
+
+        val renderTask = project.tasks.register<RenderComposePreviewsTask>(
+            "renderComposePreviews$taskSuffix"
+        ) {
+            group = TASK_GROUP
+            description = "Render Compose previews for the $variantName variant of ${project.path}."
+            this.variantName.set(variantName)
+            this.modulePath.set(project.path)
+            metadataFile.set(collectTask.flatMap { collect -> collect.outputFile })
+            outputDirectory.set(
+                project.layout.buildDirectory.dir("composePreviews/$variantName/images")
+            )
+        }
+
+        aggregateMetadata.configure { dependsOn(collectTask) }
+        aggregateRender.configure { dependsOn(renderTask) }
+        renderTask.configure { dependsOn(collectTask) }
+    }
+
+    private fun ensureAggregateTask(
+        rootProject: Project,
+        key: String,
+        name: String,
+        description: String
+    ): TaskProvider<Task> {
+        val extra = rootProject.extensions.extraProperties
+        if (extra.has(key)) {
+            val existing = extra.get(key)
+            if (existing is TaskProvider<*>) {
+                @Suppress("UNCHECKED_CAST")
+                return existing as TaskProvider<Task>
+            }
+        }
+
+        val provider = rootProject.tasks.register<Task>(name) {
+            group = TASK_GROUP
+            this.description = description
+        }
+        extra.set(key, provider)
+        return provider
+    }
+
+    private fun String.toTaskSuffix(): String =
+        replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.US) else it.toString() }
+
+    private companion object {
+        const val TASK_GROUP = "compose previews"
+    }
+}

--- a/buildSrc/src/main/kotlin/RenderComposePreviewsTask.kt
+++ b/buildSrc/src/main/kotlin/RenderComposePreviewsTask.kt
@@ -1,0 +1,54 @@
+package com.jwoglom.controlx2.build.compose
+
+import java.io.File
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+abstract class RenderComposePreviewsTask : DefaultTask() {
+    @get:InputFile
+    abstract val metadataFile: RegularFileProperty
+
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
+
+    @get:Input
+    abstract val variantName: Property<String>
+
+    @get:Input
+    abstract val modulePath: Property<String>
+
+    @TaskAction
+    fun render() {
+        val metadata = metadataFile.get().asFile
+        if (!metadata.exists()) {
+            throw IllegalStateException(
+                "Expected metadata file at ${metadata.absolutePath} for ${modulePath.get()}#${variantName.get()}"
+            )
+        }
+
+        val outputDir = outputDirectory.get().asFile
+        outputDir.mkdirs()
+
+        val marker = File(outputDir, "PLACEHOLDER.txt")
+        if (!marker.exists()) {
+            marker.writeText(
+                buildString {
+                    appendLine("Compose preview rendering is not yet implemented.")
+                    appendLine("Module: ${modulePath.get()}")
+                    appendLine("Variant: ${variantName.get()}")
+                    appendLine("Metadata: ${metadata.absolutePath}")
+                }
+            )
+        }
+
+        logger.lifecycle(
+            "Skipping Compose preview rendering for ${modulePath.get()}#${variantName.get()} (placeholder implementation)."
+        )
+    }
+}

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/com.jwoglom.controlx2.composepreviews.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/com.jwoglom.controlx2.composepreviews.properties
@@ -1,0 +1,1 @@
+implementation-class=com.jwoglom.controlx2.build.compose.ComposePreviewPlugin

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'org.jetbrains.kotlin.plugin.compose'
     id 'hu.supercluster.paperwork'
+    id 'com.jwoglom.controlx2.composepreviews'
     id 'kotlin-android'
     id 'com.google.devtools.ksp' version '2.1.10-1.0.31'
 }


### PR DESCRIPTION
## Summary
- add a buildSrc Gradle convention plugin that registers placeholder Compose preview collection/rendering tasks and aggregate entry points
- apply the plugin to the mobile module and document the partial progress in `.codex/compose-screenshots-plan.md`

## Testing
- `./gradlew :mobile:collectComposePreviewMetadataDebug --console=plain`
- `./gradlew renderAllComposePreviews --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68d04cc3272c832c8942c61be37924cc