### PR TITLE
Fix Gradle wrapper validation action failure

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -70,7 +70,7 @@ jobs:
         if: ${{ always() }} # IMPORTANT: run Android Test Report regardless
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+        uses: gradle/actions/wrapper-validation@v3
 
       - name: version
         run: echo "::set-output name=version::$(grep 'controlx2_version =' build.gradle | cut -f2 -d= | tr -d '"' | tr -d '[:space:]')"


### PR DESCRIPTION
## Summary
- switch the workflow to the maintained `gradle/actions/wrapper-validation@v3` action that runs on a supported Node.js runtime

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d109386b30832cbc850d164f086651