### PR TITLE
Reshape layoutlib fallback into Paparazzi runtime layout

### DIFF
--- a/.codex/compose-screenshots-plan.md
+++ b/.codex/compose-screenshots-plan.md
@@ -27,6 +27,12 @@
 - ✅ Ensured Paparazzi can render previews on CI even when the Android SDK's
   layoutlib jar is unavailable by falling back to the Maven-distributed layoutlib
   runtime, logging which source is used, and warning when neither path exists.
+- 🟡 Reshaped the Maven layoutlib fallback so the downloaded archive is expanded
+  into a synthetic `<runtime>/data/layoutlib.jar` layout within
+  `build/composePreviews/layoutlib/`, matching the directory structure expected
+  by Paparazzi when it derives runtime and resource roots. Pending validation of
+  renders with the synthesized runtime to confirm previews graduate from the
+  "Layoutlib jar not configured" placeholder frames.
 - ✅ Hardened the Paparazzi renderer cleanup so failed renders preserve their
   original exception messages instead of masking them with `lateinit` cleanup
   errors when Paparazzi fails before initialization completes.

--- a/buildSrc/src/main/kotlin/ComposePreviewPlugin.kt
+++ b/buildSrc/src/main/kotlin/ComposePreviewPlugin.kt
@@ -5,9 +5,16 @@ import com.android.build.api.dsl.LibraryExtension
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.api.variant.Variant
 import java.io.File
+import java.io.FileOutputStream
+import java.io.InputStream
 import java.util.Locale
 import java.util.Properties
 import java.util.concurrent.atomic.AtomicBoolean
+import java.security.MessageDigest
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -17,6 +24,10 @@ import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
 
 class ComposePreviewPlugin : Plugin<Project> {
+    companion object {
+        private val layoutlibExtractionLock = Any()
+    }
+
     override fun apply(project: Project) {
         val rootProject = project.rootProject
         val aggregateMetadata = ensureAggregateTask(
@@ -372,7 +383,85 @@ class ComposePreviewPlugin : Plugin<Project> {
             isVisible = false
         }
 
-        return runCatching { configuration.singleFile }.getOrNull()
+        val layoutlibArchive = runCatching { configuration.singleFile }.getOrNull() ?: return null
+        val version = dependencyNotation.substringAfterLast(':').ifBlank { "unspecified" }
+        val runtimeRoot = project.rootProject.layout.buildDirectory
+            .dir("composePreviews/layoutlib/$version")
+            .get()
+            .asFile
+        val dataDir = File(runtimeRoot, "data")
+        val targetJar = File(dataDir, "layoutlib.jar")
+        val checksumFile = File(runtimeRoot, "layoutlib.sha256")
+        val archiveChecksum = layoutlibArchive.sha256()
+
+        synchronized(layoutlibExtractionLock) {
+            if (targetJar.exists() && checksumFile.takeIf(File::exists)?.readText()?.trim() == archiveChecksum) {
+                return targetJar
+            }
+
+            if (runtimeRoot.exists()) {
+                runtimeRoot.deleteRecursively()
+            }
+            dataDir.mkdirs()
+
+            Files.copy(layoutlibArchive.toPath(), targetJar.toPath(), StandardCopyOption.REPLACE_EXISTING)
+            extractRuntimePayload(layoutlibArchive, runtimeRoot)
+
+            checksumFile.writeText(archiveChecksum)
+        }
+
+        return targetJar
+    }
+
+    private fun extractRuntimePayload(sourceArchive: File, runtimeRoot: File) {
+        ZipInputStream(sourceArchive.inputStream().buffered()).use { zipStream ->
+            var entry: ZipEntry? = zipStream.nextEntry
+            while (entry != null) {
+                val entryName = entry.name
+                if (entry.isDirectory) {
+                    if (entryName.startsWith("data/")) {
+                        File(runtimeRoot, entryName).mkdirs()
+                    }
+                    zipStream.closeEntry()
+                    entry = zipStream.nextEntry
+                    continue
+                }
+
+                if (entryName.startsWith("data/")) {
+                    val output = File(runtimeRoot, entryName)
+                    output.parentFile?.mkdirs()
+                    FileOutputStream(output).use { outputStream ->
+                        zipStream.copyTo(outputStream)
+                    }
+                }
+
+                zipStream.closeEntry()
+                entry = zipStream.nextEntry
+            }
+        }
+    }
+
+    private fun File.sha256(): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        inputStream().use { stream ->
+            stream.buffered().copyToDigest(digest)
+        }
+        return digest.digest().joinToString(separator = "") { byte ->
+            ((byte.toInt() and 0xFF) + 0x100).toString(16).substring(1)
+        }
+    }
+
+    private fun InputStream.copyToDigest(digest: MessageDigest) {
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        while (true) {
+            val read = read(buffer)
+            if (read == -1) {
+                break
+            }
+            if (read > 0) {
+                digest.update(buffer, 0, read)
+            }
+        }
     }
 
     private fun findAndroidSdkDirectory(project: Project): File? {


### PR DESCRIPTION
## Summary
- expand the Maven-provided layoutlib dependency into a synthetic runtime directory under `build/composePreviews/layoutlib/<version>` so Paparazzi sees the expected `data/layoutlib.jar` layout
- cache the extracted runtime with a SHA-256 marker and eagerly unpack any bundled `data/` payloads while guarding concurrent extraction with a shared lock
- document the partial completion in the compose screenshot implementation plan

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7f96469e4832cbd7ba048f1e37ab3