### PR TITLE
Update OpenAPI spec

### DIFF
--- a/mobile/src/main/assets/openapi.json
+++ b/mobile/src/main/assets/openapi.json
@@ -147,6 +147,39 @@
         }
       }
     },
+    "/": {
+      "get": {
+        "summary": "Get debug API version info",
+        "description": "Returns ControlX2 and PumpX2 build metadata for the debug API instance",
+        "responses": {
+          "200": {
+            "description": "Version info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "version": {"type": "string"},
+                    "buildVersion": {"type": "string"},
+                    "buildTime": {"type": "string"},
+                    "pumpx2": {
+                      "type": "object",
+                      "properties": {
+                        "version": {"type": "string"},
+                        "buildTime": {"type": "string"}
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
     "/api/pump/current": {
       "get": {
         "summary": "Get current pump data",
@@ -368,6 +401,15 @@
       "get": {
         "summary": "History log status",
         "description": "Returns counts and newest/oldest sequence info for the history log table",
+        "parameters": [
+          {
+            "name": "pumpSid",
+            "in": "query",
+            "required": false,
+            "schema": {"type": "integer"},
+            "description": "Optional pump SID to query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Status summary",
@@ -472,6 +514,15 @@
     "/api/historylog/types": {
       "get": {
         "summary": "List available history log types",
+        "parameters": [
+          {
+            "name": "pumpSid",
+            "in": "query",
+            "required": false,
+            "schema": {"type": "integer"},
+            "description": "Optional pump SID to query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Types with counts",
@@ -490,6 +541,20 @@
             }
           },
           "401": {"description": "Unauthorized"}
+        }
+      }
+    },
+    "/api/pump/debug-write-bt-characteristic": {
+      "post": {
+        "summary": "Debug write to pump BLE characteristic",
+        "description": "Debug-only endpoint for writing raw values to a BLE characteristic. Currently returns an empty response.",
+        "responses": {
+          "200": {
+            "description": "Empty response"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },


### PR DESCRIPTION
### Motivation
- The mobile HTTP debug service exposes a root (`/`) version/info endpoint, accepts an optional `pumpSid` query parameter on several history log endpoints, and has a debug BLE write handler, but the shipped OpenAPI spec did not reflect these behaviors.
- Keeping the OpenAPI document in sync with the running `HttpDebugApiService` improves discoverability and tooling for debugging clients.

### Description
- Added documentation for the root `/` GET endpoint that returns ControlX2 and PumpX2 build metadata to `mobile/src/main/assets/openapi.json`.
- Added optional `pumpSid` query parameters to `/api/historylog/status` and `/api/historylog/types` to match the service behavior.
- Documented the debug-only `/api/pump/debug-write-bt-characteristic` POST endpoint (currently returns an empty response) in the OpenAPI spec.

### Testing
- No automated tests were run because this is a documentation-only change to `mobile/src/main/assets/openapi.json`.
- Manual verification was performed by inspecting the `HttpDebugApiService` routes to ensure the spec entries correspond to implemented handlers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697573ca8c0c832ca12df5dc749a6b4e)