### PR TITLE
Add glucose unit preference sync between mobile and wear apps

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/CommService.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/CommService.kt
@@ -362,6 +362,11 @@ class CommService : Service() {
                 sendWearCommMessage("/from-pump/pump-connected",
                     peripheral?.name!!.toByteArray()
                 )
+                // Sync glucose unit preference to wear app
+                val glucoseUnit = Prefs(applicationContext).glucoseUnit()
+                if (glucoseUnit != null) {
+                    sendWearCommMessage("/to-wear/glucose-unit", glucoseUnit.name.toByteArray())
+                }
                 currentPumpData.connectionTime = Instant.now()
                 updateNotification("Connected to pump")
             }

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/AppSetup.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/AppSetup.kt
@@ -320,8 +320,9 @@ fun AppSetup(
                                     Prefs(context).setGlucoseUnit(unit)
                                     ds.glucoseUnitPreference.value = unit
                                     showGlucoseUnitDialog = false
-                                    // Trigger app reload
+                                    // Sync glucose unit to wear app and trigger reload
                                     coroutineScope.launch {
+                                        sendMessage("/to-wear/glucose-unit", unit.name.toByteArray())
                                         withContext(Dispatchers.IO) {
                                             Thread.sleep(250)
                                         }

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/BolusWindow.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/BolusWindow.kt
@@ -83,6 +83,7 @@ import com.jwoglom.controlx2.presentation.screens.sections.components.DecimalOut
 import com.jwoglom.controlx2.presentation.screens.sections.components.IntegerOutlinedText
 import com.jwoglom.controlx2.presentation.util.LifecycleStateObserver
 import com.jwoglom.controlx2.shared.enums.GlucoseUnit
+import com.jwoglom.controlx2.shared.util.GlucoseConverter
 import com.jwoglom.controlx2.shared.util.SendType
 import com.jwoglom.controlx2.shared.util.snakeCaseToSpace
 import com.jwoglom.controlx2.shared.util.twoDecimalPlaces
@@ -211,12 +212,22 @@ fun BolusWindow(
     }
 
     fun recalculate() {
+        // Convert glucose from display unit to mg/dL for the bolus calculator
+        val glucoseDisplayValue = rawToInt(glucoseRawValue.value)
+        val glucoseMgdlValue = when {
+            glucoseDisplayValue == null -> null
+            glucoseUnit == GlucoseUnit.MMOL -> {
+                val displayDouble = glucoseRawValue.value?.toDoubleOrNull()
+                displayDouble?.let { GlucoseConverter.convert(it, GlucoseUnit.MMOL, GlucoseUnit.MGDL).toInt() }
+            }
+            else -> glucoseDisplayValue
+        }
         dataStore.bolusCalculatorBuilder.value = buildBolusCalculator(
             bolusCalcDataSnapshot.value,
             bolusCalcLastBG.value,
             if (unitsHumanEntered != null) rawToDouble(unitsRawValue.value) else null,
             rawToInt(carbsRawValue.value),
-            rawToInt(glucoseRawValue.value)
+            glucoseMgdlValue
         )
 
         dataStore.bolusCurrentParameters.value =
@@ -290,7 +301,7 @@ fun BolusWindow(
             dataStore.bolusCurrentParameters.value!!.glucoseMgdl > 0 &&
             autofilledBg != null
         ) {
-            dataStore.bolusGlucoseRawValue.value = "$autofilledBg"
+            dataStore.bolusGlucoseRawValue.value = GlucoseConverter.format(autofilledBg, glucoseUnit)
         }
         glucoseSubtitle = when {
             glucoseHumanEntered != null -> "Entered ($unitAbbrev)"

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/VicoCgmChart.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/VicoCgmChart.kt
@@ -839,9 +839,17 @@ fun VicoCgmChart(
             textAlign = TextAlign.Center
         )
     } else {
-        val yAxisLabels = remember(fixedGlucoseRange) {
-            //listOf("400", "360", "320", "280", "240", "200", "160", "120", "80", "40")
-            listOf("400", " ", " ", "280", " ", "200", "160", "120", "80", "40")
+        val yAxisLabels = remember(fixedGlucoseRange, glucoseUnit) {
+            val mgdlValues = listOf(400, 360, 320, 280, 240, 200, 160, 120, 80, 40)
+            val sparseIndices = setOf(0, 3, 5, 6, 7, 8, 9) // indices to show labels for
+            when (glucoseUnit) {
+                GlucoseUnit.MGDL -> mgdlValues.mapIndexed { i, v ->
+                    if (i in sparseIndices) "$v" else " "
+                }
+                GlucoseUnit.MMOL -> mgdlValues.mapIndexed { i, v ->
+                    if (i in sparseIndices) String.format("%.1f", v * GlucoseConverter.MGDL_TO_MMOL_FACTOR) else " "
+                }
+            }
         }
 
         // Create persistent markers for bolus events

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/dialogs/AddProfileDialog.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/dialogs/AddProfileDialog.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.unit.dp
 import com.jwoglom.controlx2.LocalDataStore
 import com.jwoglom.controlx2.presentation.theme.ControlX2Theme
 import com.jwoglom.controlx2.shared.enums.GlucoseUnit
+import com.jwoglom.controlx2.shared.util.GlucoseConverter
+import kotlin.math.roundToInt
 
 @Composable
 fun AddProfileDialog(
@@ -39,8 +41,14 @@ fun AddProfileDialog(
     var profileName by remember { mutableStateOf("") }
     var carbRatio by remember { mutableStateOf("10") }
     var basalRate by remember { mutableStateOf("1.0") }
-    var targetBG by remember { mutableStateOf("110") }
-    var isf by remember { mutableStateOf("50") }
+    var targetBG by remember { mutableStateOf(when (glucoseUnit) {
+        GlucoseUnit.MGDL -> "110"
+        GlucoseUnit.MMOL -> "6.1"
+    }) }
+    var isf by remember { mutableStateOf(when (glucoseUnit) {
+        GlucoseUnit.MGDL -> "50"
+        GlucoseUnit.MMOL -> "2.8"
+    }) }
     var insulinDuration by remember { mutableStateOf("240") }
     var carbEntryEnabled by remember { mutableStateOf(true) }
 
@@ -96,8 +104,11 @@ fun AddProfileDialog(
                         value = targetBG,
                         onValueChange = { targetBG = it },
                         label = { Text("Target BG ($unitAbbrev)") },
-                        supportingText = { Text("Example: 110") },
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        supportingText = { Text(when (glucoseUnit) {
+                            GlucoseUnit.MGDL -> "Example: 110"
+                            GlucoseUnit.MMOL -> "Example: 6.1"
+                        }) },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
                         modifier = Modifier.fillMaxWidth()
                     )
                 }
@@ -112,7 +123,7 @@ fun AddProfileDialog(
                                 GlucoseUnit.MMOL -> "Example: 2.8 = 1u:2.8 mmol/L"
                             })
                         },
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
                         modifier = Modifier.fillMaxWidth()
                     )
                 }
@@ -133,16 +144,29 @@ fun AddProfileDialog(
                 onClick = {
                     val carbRatioInt = (carbRatio.toFloatOrNull() ?: 10f) * 1000
                     val basalRateMilliunits = ((basalRate.toFloatOrNull() ?: 1.0f) * 1000).toInt()
-                    val targetBGInt = targetBG.toIntOrNull() ?: 110
-                    val isfInt = isf.toIntOrNull() ?: 50
+                    // Convert glucose values from display unit to mg/dL for pump
+                    val targetBGMgdl = when (glucoseUnit) {
+                        GlucoseUnit.MGDL -> targetBG.toIntOrNull() ?: 110
+                        GlucoseUnit.MMOL -> GlucoseConverter.convert(
+                            targetBG.toDoubleOrNull() ?: 6.1,
+                            GlucoseUnit.MMOL, GlucoseUnit.MGDL
+                        ).roundToInt()
+                    }
+                    val isfMgdl = when (glucoseUnit) {
+                        GlucoseUnit.MGDL -> isf.toIntOrNull() ?: 50
+                        GlucoseUnit.MMOL -> GlucoseConverter.convert(
+                            isf.toDoubleOrNull() ?: 2.8,
+                            GlucoseUnit.MMOL, GlucoseUnit.MGDL
+                        ).roundToInt()
+                    }
                     val insulinDurationInt = insulinDuration.toIntOrNull() ?: 240
 
                     onConfirm(
                         profileName,
                         carbRatioInt.toInt(),
                         basalRateMilliunits,
-                        targetBGInt,
-                        isfInt,
+                        targetBGMgdl,
+                        isfMgdl,
                         insulinDurationInt,
                         carbEntryEnabled
                     )

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/dialogs/EditSegmentDialog.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/dialogs/EditSegmentDialog.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.unit.sp
 import com.jwoglom.controlx2.LocalDataStore
 import com.jwoglom.controlx2.presentation.theme.ControlX2Theme
 import com.jwoglom.controlx2.shared.enums.GlucoseUnit
+import com.jwoglom.controlx2.shared.util.GlucoseConverter
+import kotlin.math.roundToInt
 import com.jwoglom.pumpx2.pump.messages.builders.IDPManager
 import com.jwoglom.pumpx2.pump.messages.models.InsulinUnit
 import com.jwoglom.pumpx2.pump.messages.models.MinsTime
@@ -58,8 +60,12 @@ fun EditSegmentDialog(
     )
     var basalRate by remember { mutableStateOf(InsulinUnit.from1000To1(segment.profileBasalRate.toLong()).toString()) }
     var carbRatio by remember { mutableStateOf(segment.profileCarbRatio.toString()) }
-    var targetBG by remember { mutableStateOf(segment.profileTargetBG.toString()) }
-    var isf by remember { mutableStateOf(segment.profileISF.toString()) }
+    var targetBG by remember { mutableStateOf(
+        GlucoseConverter.format(segment.profileTargetBG, glucoseUnit)
+    ) }
+    var isf by remember { mutableStateOf(
+        GlucoseConverter.format(segment.profileISF, glucoseUnit)
+    ) }
     var errorMessage by remember { mutableStateOf("") }
 
     AlertDialog(
@@ -115,9 +121,12 @@ fun EditSegmentDialog(
                     OutlinedTextField(
                         value = targetBG,
                         onValueChange = { targetBG = it },
-                        label = { Text("Target BG") },
-                        placeholder = { Text("e.g., 110") },
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        label = { Text("Target BG (${glucoseUnit.abbreviation})") },
+                        placeholder = { Text(when (glucoseUnit) {
+                            GlucoseUnit.MGDL -> "e.g., 110"
+                            GlucoseUnit.MMOL -> "e.g., 6.1"
+                        }) },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
                         modifier = Modifier.fillMaxWidth()
                     )
                 }
@@ -125,15 +134,18 @@ fun EditSegmentDialog(
                     OutlinedTextField(
                         value = isf,
                         onValueChange = { isf = it },
-                        label = { Text("ISF (Insulin Sensitivity Factor)") },
+                        label = { Text("ISF (${glucoseUnit.abbreviation} per u)") },
                         supportingText = {
                             Text(when (glucoseUnit) {
                                 GlucoseUnit.MGDL -> "Example: 50 = 1u:50 mg/dL"
                                 GlucoseUnit.MMOL -> "Example: 2.8 = 1u:2.8 mmol/L"
                             })
                         },
-                        placeholder = { Text("e.g., 50") },
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        placeholder = { Text(when (glucoseUnit) {
+                            GlucoseUnit.MGDL -> "e.g., 50"
+                            GlucoseUnit.MMOL -> "e.g., 2.8"
+                        }) },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
                         modifier = Modifier.fillMaxWidth()
                     )
                 }
@@ -157,8 +169,21 @@ fun EditSegmentDialog(
                         val newStartTime = MinsTime(hours, minutes)
                         val basalRateFloat = basalRate.toFloatOrNull() ?: 0f
                         val carbRatioLong = carbRatio.toLongOrNull() ?: 0L
-                        val targetBGInt = targetBG.toIntOrNull() ?: 0
-                        val isfInt = isf.toIntOrNull() ?: 0
+                        // Convert glucose values from display unit to mg/dL for pump
+                        val targetBGMgdl = when (glucoseUnit) {
+                            GlucoseUnit.MGDL -> targetBG.toIntOrNull() ?: 0
+                            GlucoseUnit.MMOL -> GlucoseConverter.convert(
+                                targetBG.toDoubleOrNull() ?: 0.0,
+                                GlucoseUnit.MMOL, GlucoseUnit.MGDL
+                            ).roundToInt()
+                        }
+                        val isfMgdl = when (glucoseUnit) {
+                            GlucoseUnit.MGDL -> isf.toIntOrNull() ?: 0
+                            GlucoseUnit.MMOL -> GlucoseConverter.convert(
+                                isf.toDoubleOrNull() ?: 0.0,
+                                GlucoseUnit.MMOL, GlucoseUnit.MGDL
+                            ).roundToInt()
+                        }
 
                         if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) {
                             errorMessage = "Invalid time. Hours must be 0-23, minutes must be 0-59."
@@ -172,16 +197,16 @@ fun EditSegmentDialog(
                             errorMessage = "Carb ratio must be greater than 0"
                             return@TextButton
                         }
-                        if (targetBGInt <= 0) {
+                        if (targetBGMgdl <= 0) {
                             errorMessage = "Target BG must be greater than 0"
                             return@TextButton
                         }
-                        if (isfInt <= 0) {
+                        if (isfMgdl <= 0) {
                             errorMessage = "ISF must be greater than 0"
                             return@TextButton
                         }
 
-                        onConfirm(newStartTime, basalRateFloat, carbRatioLong, targetBGInt, isfInt)
+                        onConfirm(newStartTime, basalRateFloat, carbRatioLong, targetBGMgdl, isfMgdl)
                     } catch (e: Exception) {
                         errorMessage = "Error: ${e.message}"
                         Timber.e(e, "Error updating segment")

--- a/wear/src/main/java/com/jwoglom/controlx2/MainActivity.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/MainActivity.kt
@@ -513,6 +513,15 @@ class MainActivity : ComponentActivity(), MessageClient.OnMessageReceivedListene
             "/to-wear/bolus-min-notify-threshold" -> {
                 dataStore.bolusMinNotifyThreshold.value = String(messageEvent.data).toDoubleOrNull()
             }
+            "/to-wear/glucose-unit" -> {
+                val unitName = String(messageEvent.data)
+                val unit = com.jwoglom.controlx2.shared.enums.GlucoseUnit.fromName(unitName)
+                if (unit != null) {
+                    dataStore.glucoseUnitPreference.value = unit
+                    com.jwoglom.controlx2.util.StatePrefs(applicationContext).glucoseUnit = unit
+                    com.jwoglom.controlx2.util.UpdateComplication(this, com.jwoglom.controlx2.util.WearX2Complication.CGM_READING)
+                }
+            }
             "/to-wear/initiate-confirmed-bolus" -> {
                 if (inWaitingState()) {
                     Timber.e("in invalid state for initiate-confirmed-bolus")

--- a/wear/src/main/java/com/jwoglom/controlx2/PhoneCommService.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/PhoneCommService.kt
@@ -147,6 +147,14 @@ class PhoneCommService : Service() {
                 val pumpMessage = PumpMessageSerializer.fromBytes(data)
                 onPumpMessageReceived(pumpMessage, false)
             }
+            "/to-wear/glucose-unit" -> {
+                val unitName = String(data)
+                val unit = com.jwoglom.controlx2.shared.enums.GlucoseUnit.fromName(unitName)
+                if (unit != null) {
+                    StatePrefs(applicationContext).glucoseUnit = unit
+                    UpdateComplication(this, WearX2Complication.CGM_READING)
+                }
+            }
         }
     }
 

--- a/wear/src/main/java/com/jwoglom/controlx2/complications/CGMReadingComplicationDataSourceService.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/complications/CGMReadingComplicationDataSourceService.kt
@@ -19,6 +19,8 @@ import androidx.wear.watchface.complications.datasource.ComplicationRequest
 import androidx.wear.watchface.complications.datasource.SuspendingComplicationDataSourceService
 import com.jwoglom.controlx2.MainActivity
 import com.jwoglom.controlx2.R
+import com.jwoglom.controlx2.shared.enums.GlucoseUnit
+import com.jwoglom.controlx2.shared.util.GlucoseConverter
 import com.jwoglom.controlx2.util.StatePrefs
 import java.time.Duration
 import java.time.Instant
@@ -33,11 +35,13 @@ class CGMReadingComplicationDataSourceService : SuspendingComplicationDataSource
         Log.i(tag, "onComplicationRequest(${request.complicationType}, ${request.complicationInstanceId}, ${request.immediateResponseRequired})")
 
         val tapIntent = PendingIntent.getActivity(this, 0, Intent(this, MainActivity::class.java), PendingIntent.FLAG_IMMUTABLE)
-        val pumpIOB = StatePrefs(this).cgmReading
+        val statePrefs = StatePrefs(this)
+        val pumpIOB = statePrefs.cgmReading
+        val glucoseUnit = statePrefs.glucoseUnit
 
         return getComplicationDataForType(
             request.complicationType,
-            buildDataFields(readingPair = pumpIOB),
+            buildDataFields(readingPair = pumpIOB, glucoseUnit = glucoseUnit),
             tapIntent,
         )
     }
@@ -57,7 +61,8 @@ class CGMReadingComplicationDataSourceService : SuspendingComplicationDataSource
 
     override fun getPreviewData(type: ComplicationType): ComplicationData? {
         val data = buildDataFields(
-            readingPair = Pair("15.00", Instant.now())
+            readingPair = Pair("15.00", Instant.now()),
+            glucoseUnit = StatePrefs(this).glucoseUnit
         )
         return getComplicationDataForType(type, data, null)
     }
@@ -72,8 +77,9 @@ class CGMReadingComplicationDataSourceService : SuspendingComplicationDataSource
 
     private fun buildDataFields(
         readingPair: Pair<String, Instant>?,
+        glucoseUnit: GlucoseUnit = GlucoseUnit.MGDL,
     ): DataFields {
-        Log.i(tag, "buildDataFields($readingPair)")
+        Log.i(tag, "buildDataFields($readingPair, $glucoseUnit)")
 
         val text: ComplicationText
         val monochromaticImage: MonochromaticImage?
@@ -83,7 +89,7 @@ class CGMReadingComplicationDataSourceService : SuspendingComplicationDataSource
             Duration.between(it, Instant.now())
         } ?: Duration.ZERO
         val cgmNum = readingPair?.first?.toIntOrNull() ?: 0
-        val cgmLabel = "$cgmNum"
+        val cgmLabel = GlucoseConverter.format(cgmNum, glucoseUnit)
         var displayType = ""
 
         when {
@@ -134,8 +140,9 @@ class CGMReadingComplicationDataSourceService : SuspendingComplicationDataSource
             text = "${caseContentDescription}: $cgmLabel"
         ).build()
 
+        val cgmDisplayValue = GlucoseConverter.convert(cgmNum.toDouble(), GlucoseUnit.MGDL, glucoseUnit).toFloat()
         return DataFields(
-            cgmValue = cgmNum.toFloat(),
+            cgmValue = cgmDisplayValue,
             contentDescription = contentDescription,
             text = text,
             monochromaticImage = monochromaticImage,
@@ -147,10 +154,12 @@ class CGMReadingComplicationDataSourceService : SuspendingComplicationDataSource
         data: DataFields,
         tapAction: PendingIntent?
     ): ComplicationData {
+        val glucoseUnit = StatePrefs(this).glucoseUnit
+        val maxValue = GlucoseConverter.convert(MaxMgdl.toDouble(), GlucoseUnit.MGDL, glucoseUnit).toFloat()
         return RangedValueComplicationData.Builder(
             value = data.cgmValue,
             min = 0f,
-            max = MaxMgdl.toFloat(),
+            max = maxValue,
             contentDescription = data.contentDescription
         )
 //            .setColorRamp(ColorRamp(

--- a/wear/src/main/java/com/jwoglom/controlx2/presentation/WearApp.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/presentation/WearApp.kt
@@ -84,6 +84,7 @@ import com.jwoglom.controlx2.presentation.ui.IndeterminateProgressIndicator
 import com.jwoglom.controlx2.presentation.ui.LandingScreen
 import com.jwoglom.controlx2.presentation.ui.ScalingLazyListStateViewModel
 import com.jwoglom.controlx2.presentation.ui.ScrollStateViewModel
+import com.jwoglom.controlx2.shared.enums.GlucoseUnit
 import com.jwoglom.controlx2.shared.enums.UserMode
 import com.jwoglom.controlx2.shared.util.SendType
 import com.jwoglom.pumpx2.pump.messages.request.control.SetModesRequest
@@ -521,9 +522,10 @@ fun WearApp(
 
                 composable(Screen.BolusSelectBGScreen.route) {
                     val currentBG = LocalDataStore.current.bolusCalculatorBuilder.value?.glucoseMgdl?.orElse(null)
+                    val glucoseUnit = LocalDataStore.current.glucoseUnitPreference.value ?: GlucoseUnit.MGDL
 
                     SingleNumberPicker(
-                        label = "BG",
+                        label = "BG (${glucoseUnit.abbreviation})",
                         minNumber = 40,
                         maxNumber = 400,
                         defaultNumber = when {

--- a/wear/src/main/java/com/jwoglom/controlx2/presentation/components/CurrentCGMText.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/presentation/components/CurrentCGMText.kt
@@ -19,6 +19,8 @@ import com.google.common.base.Strings
 import com.jwoglom.controlx2.LocalDataStore
 import com.jwoglom.controlx2.presentation.defaultTheme
 import com.jwoglom.controlx2.presentation.redTheme
+import com.jwoglom.controlx2.shared.enums.GlucoseUnit
+import com.jwoglom.controlx2.shared.util.GlucoseConverter
 
 @Composable
 fun CurrentCGMText(
@@ -31,13 +33,14 @@ fun CurrentCGMText(
     val cgmStatusText = ds.cgmStatusText.observeAsState()
     val cgmHighLowState = ds.cgmHighLowState.observeAsState()
     val cgmDeltaArrow = ds.cgmDeltaArrow.observeAsState()
+    val glucoseUnit = ds.glucoseUnitPreference.observeAsState()
     val displayText = when (cgmSessionState.value) {
         "Starting", "Stopped", "Stopping", "Unknown" -> cgmStatusText.value!!
         else -> when {
             !Strings.isNullOrEmpty(cgmStatusText.value) -> cgmStatusText.value!!
             else -> when {
-                cgmReading.value != null && cgmDeltaArrow.value != null -> "${cgmReading.value} ${cgmDeltaArrow.value}"
-                cgmReading.value != null -> "${cgmReading.value}"
+                cgmReading.value != null && cgmDeltaArrow.value != null -> "${GlucoseConverter.format(cgmReading.value!!, glucoseUnit.value ?: GlucoseUnit.MGDL)} ${cgmDeltaArrow.value}"
+                cgmReading.value != null -> GlucoseConverter.format(cgmReading.value!!, glucoseUnit.value ?: GlucoseUnit.MGDL)
                 else -> ""
             }
         }
@@ -104,14 +107,16 @@ fun CurvedScope.currentCGMTextCurvedExcludingDeltaArrow(
     cgmReading: Int?,
     cgmDeltaArrow: String?,
     cgmHighLowState: String?,
+    glucoseUnit: GlucoseUnit = GlucoseUnit.MGDL,
 ) {
+    val formattedReading = cgmReading?.let { GlucoseConverter.format(it, glucoseUnit) }
     val displayText = when (cgmSessionState) {
         "Starting", "Stopped", "Stopping", "Unknown" -> cgmStatusText
         else -> when {
             !Strings.isNullOrEmpty(cgmStatusText) -> cgmStatusText
             else -> when {
-                cgmReading != null && cgmDeltaArrow != null -> "${cgmReading}"
-                cgmReading != null -> "${cgmReading}"
+                formattedReading != null && cgmDeltaArrow != null -> formattedReading
+                formattedReading != null -> formattedReading
                 else -> ""
             }
         }

--- a/wear/src/main/java/com/jwoglom/controlx2/presentation/components/TopText.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/presentation/components/TopText.kt
@@ -19,6 +19,7 @@ import androidx.wear.compose.material.TimeText
 import androidx.wear.compose.material.TimeTextDefaults
 import androidx.wear.compose.material.curvedText
 import com.jwoglom.controlx2.LocalDataStore
+import com.jwoglom.controlx2.shared.enums.GlucoseUnit
 
 
 @Composable
@@ -51,6 +52,7 @@ fun TopText(
         val cgmStatusText = ds.cgmStatusText.observeAsState()
         val cgmHighLowState = ds.cgmHighLowState.observeAsState()
         val cgmDeltaArrow = ds.cgmDeltaArrow.observeAsState()
+        val glucoseUnit = ds.glucoseUnitPreference.observeAsState()
         TimeText(
             modifier = modifier,
             startCurvedContent = if (visibleText) {
@@ -77,7 +79,8 @@ fun TopText(
                     cgmStatusText.value,
                     cgmReading.value,
                     cgmDeltaArrow.value,
-                    cgmHighLowState.value
+                    cgmHighLowState.value,
+                    glucoseUnit.value ?: GlucoseUnit.MGDL
                 )
                 curvedComposable (radialAlignment = CurvedAlignment.Radial.Outer) {
                     CurrentCGMTextDeltaArrow(textStyle, modifier = Modifier.padding(start = 2.dp))

--- a/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/BolusScreen.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/BolusScreen.kt
@@ -81,6 +81,7 @@ import com.jwoglom.controlx2.presentation.DataStore
 import com.jwoglom.controlx2.presentation.components.LineTextDescription
 import com.jwoglom.controlx2.presentation.defaultTheme
 import com.jwoglom.controlx2.shared.enums.GlucoseUnit
+import com.jwoglom.controlx2.shared.util.GlucoseConverter
 import com.jwoglom.controlx2.shared.presentation.LifecycleStateObserver
 import com.jwoglom.controlx2.shared.util.SendType
 import com.jwoglom.controlx2.shared.util.firstLetterCapitalized
@@ -336,8 +337,8 @@ fun BolusScreen(
 
             val autofilledBg = dataStore.bolusCalculatorBuilder.value?.glucoseMgdl?.orElse(null)
             dataStore.bolusBGDisplayedText.value = when {
-                bolusBgMgdlUserInput != null -> "$bolusBgMgdlUserInput"
-                autofilledBg != null -> "$autofilledBg"
+                bolusBgMgdlUserInput != null -> GlucoseConverter.format(bolusBgMgdlUserInput!!, glucoseUnit)
+                autofilledBg != null -> GlucoseConverter.format(autofilledBg, glucoseUnit)
                 else -> "?"
             }
             dataStore.bolusBGDisplayedSubtitle.value = when {

--- a/wear/src/main/java/com/jwoglom/controlx2/util/StatePrefs.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/util/StatePrefs.kt
@@ -3,6 +3,7 @@ package com.jwoglom.controlx2.util
 import android.content.Context
 import android.content.SharedPreferences
 import com.google.android.gms.wearable.WearableListenerService
+import com.jwoglom.controlx2.shared.enums.GlucoseUnit
 import timber.log.Timber
 import java.time.Instant
 
@@ -29,6 +30,16 @@ class StatePrefs(val context: Context) {
         get() = get("cgmReading")
         set(value) {
             set("cgmReading", value)
+        }
+
+    var glucoseUnit: GlucoseUnit
+        get() {
+            val name = prefs().getString("StatePrefs_glucoseUnit", null)
+            return GlucoseUnit.fromName(name) ?: GlucoseUnit.MGDL
+        }
+        set(value) {
+            Timber.d("StatePrefs set glucoseUnit=$value")
+            prefs().edit().putString("StatePrefs_glucoseUnit", value.name).apply()
         }
 
     private fun get(key: String): Pair<String, Instant>? {


### PR DESCRIPTION
## Summary
This PR adds support for syncing glucose unit preferences (mg/dL vs mmol/L) between the mobile and wear apps, and ensures all glucose-related UI elements display values in the user's preferred unit.

## Key Changes

### Mobile App (CommService & UI Screens)
- **CommService**: Automatically syncs glucose unit preference to wear app when pump connects
- **AppSetup**: Sends glucose unit preference to wear app when user changes the setting
- **BolusWindow**: Converts glucose input from display unit to mg/dL before passing to bolus calculator
- **VicoCgmChart**: Displays Y-axis labels in the user's preferred glucose unit
- **AddProfileDialog & EditSegmentDialog**: 
  - Initialize default values based on glucose unit (110 mg/dL vs 6.1 mmol/L for target BG)
  - Accept decimal input for mmol/L values
  - Convert user input from display unit to mg/dL before sending to pump

### Wear App (MainActivity, PhoneCommService & UI Components)
- **MainActivity & PhoneCommService**: Receive and persist glucose unit preference from mobile app
- **CGMReadingComplicationDataSourceService**: 
  - Formats CGM readings in the user's preferred unit
  - Adjusts complication max value based on glucose unit
- **CurrentCGMText & TopText**: Display CGM readings in the user's preferred unit
- **BolusScreen**: Shows BG input label with glucose unit abbreviation and formats displayed values
- **StatePrefs**: Added persistent storage for glucose unit preference on wear device

## Implementation Details
- Uses `GlucoseConverter` utility for unit conversions (mg/dL ↔ mmol/L)
- Maintains mg/dL as the internal pump communication standard
- All user-facing glucose values are converted to/from the display unit
- Preference syncs automatically on pump connection and when manually changed
- Wear app updates complications when glucose unit preference changes

https://claude.ai/code/session_01Ndi9uKiXFsK79ipEGMCJSh