### PR TITLE
Stabilize WearApp connection checks across navigation and lifecycle events

### DIFF
--- a/wear/src/main/java/com/jwoglom/controlx2/presentation/WearApp.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/presentation/WearApp.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
+import android.os.SystemClock
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.DirectionsRun
 import androidx.compose.material.icons.filled.KingBed
@@ -90,6 +91,7 @@ import com.jwoglom.controlx2.shared.util.SendType
 import com.jwoglom.pumpx2.pump.messages.request.control.SetModesRequest
 import kotlin.math.abs
 import kotlin.math.pow
+import kotlinx.coroutines.awaitCancellation
 
 @Composable
 fun WearApp(
@@ -134,6 +136,7 @@ fun WearApp(
         // later navigate into it again, it should be in its initial scroll state (not the last
         // scroll location it was in before you backed out).
         val currentBackStackEntry by navController.currentBackStackEntryAsState()
+        val currentRoute = currentBackStackEntry?.destination?.route
 
         val scrollType =
             currentBackStackEntry?.arguments?.getSerializable(SCROLL_TYPE_NAV_ARGUMENT)
@@ -156,8 +159,28 @@ fun WearApp(
             navController.navigate(Screen.WaitingForPhone.route)
         }
 
-        LaunchedEffect (navController.currentDestination) {
-            sendPhoneConnectionCheck()
+        val lifecycleOwner = LocalLifecycleOwner.current
+        val connectionCheckMinIntervalMs = 1500L
+        var lastConnectionCheckTimestampMs by remember { mutableStateOf(0L) }
+        val requestConnectionCheck = {
+            val now = SystemClock.elapsedRealtime()
+            if (now - lastConnectionCheckTimestampMs >= connectionCheckMinIntervalMs) {
+                lastConnectionCheckTimestampMs = now
+                sendPhoneConnectionCheck()
+            }
+        }
+
+        LaunchedEffect(currentRoute) {
+            if (currentRoute != null) {
+                requestConnectionCheck()
+            }
+        }
+
+        LaunchedEffect(lifecycleOwner) {
+            lifecycleOwner.repeatOnLifecycle(state = Lifecycle.State.RESUMED) {
+                requestConnectionCheck()
+                awaitCancellation()
+            }
         }
 
         Scaffold(


### PR DESCRIPTION
### Motivation
- Reduce duplicate connection-check messages caused by incidental recompositions and rapid navigation changes. 
- Ensure connection checks run on meaningful events (stable route changes and lifecycle resume) instead of every UI recomposition.

### Description
- Replace the previous `LaunchedEffect(navController.currentDestination)` trigger with a stable route signal derived from `currentBackStackEntryAsState()` using `currentRoute` and `LaunchedEffect(currentRoute)`. 
- Add a throttled gate `requestConnectionCheck` that uses `SystemClock.elapsedRealtime()` and `connectionCheckMinIntervalMs = 1500L` to debounce rapid requests and avoid spamming `sendPhoneConnectionCheck()`. 
- Add a lifecycle-driven check inside `repeatOnLifecycle(Lifecycle.State.RESUMED)` so a connection check runs when the UI resumes, and keep the resumed block active using `awaitCancellation()`. 
- Add imports for `android.os.SystemClock` and `kotlinx.coroutines.awaitCancellation` and local `lastConnectionCheckTimestampMs` tracking state in the `WearApp` composable. The change is in `wear/src/main/java/com/jwoglom/controlx2/presentation/WearApp.kt`.

### Testing
- Ran `./gradlew :wear:compileDebugKotlin --console=plain` to validate Kotlin compilation; build failed in this environment due to a missing `local.properties` file (environment setup issue), so compilation could not be fully verified.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5299995e0832c879abcbe337c838c)