### PR TITLE
Move wear message deserialization off main thread

### DIFF
--- a/wear/src/main/java/com/jwoglom/controlx2/MainActivity.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/MainActivity.kt
@@ -72,7 +72,11 @@ import com.jwoglom.pumpx2.pump.messages.response.currentStatus.TimeSinceResetRes
 import com.jwoglom.pumpx2.pump.messages.response.historyLog.BolusDeliveryHistoryLog
 import com.jwoglom.pumpx2.pump.messages.response.qualifyingEvent.QualifyingEvent
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asExecutor
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.time.temporal.ChronoUnit
 import kotlin.math.roundToInt
@@ -86,6 +90,7 @@ class MainActivity : ComponentActivity(), MessageClient.OnMessageReceivedListene
     private lateinit var messageClient: MessageClient
 
     private lateinit var initialRoute: String
+    private val uiScope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
@@ -291,6 +296,7 @@ class MainActivity : ComponentActivity(), MessageClient.OnMessageReceivedListene
 
     override fun onDestroy() {
         messageClient.removeListener(this)
+        uiScope.cancel()
         super.onDestroy()
     }
 
@@ -523,35 +529,34 @@ class MainActivity : ComponentActivity(), MessageClient.OnMessageReceivedListene
                 }
             }
             "/to-wear/initiate-confirmed-bolus" -> {
-                if (inWaitingState()) {
-                    Timber.e("in invalid state for initiate-confirmed-bolus")
-                    runOnUiThread {
+                uiScope.launch {
+                    if (inWaitingState()) {
+                        Timber.e("in invalid state for initiate-confirmed-bolus")
                         navController.navigate(Screen.BolusBlocked.route)
+                        return@launch
                     }
-                    return
-                }
 
-                if (navController.currentDestination?.route != Screen.Bolus.route) {
-                    Timber.e("in non-bolus state for initiate-confirmed-bolus")
-                    runOnUiThread {
+                    if (navController.currentDestination?.route != Screen.Bolus.route) {
+                        Timber.e("in non-bolus state for initiate-confirmed-bolus")
                         navController.navigate(Screen.BolusBlocked.route)
+                        return@launch
                     }
-                    return
-                }
 
-                val dataStoreUnits = dataStore.bolusFinalParameters.value?.units
-                val confirmedBolus = InitiateConfirmedBolusSerializer.fromBytes("IGNORED_BY_WEAR", messageEvent.data)
-                val initiateBolusRequest = confirmedBolus.right as InitiateBolusRequest
-                if (initiateBolusRequest.totalVolume != InsulinUnit.from1To1000(dataStoreUnits)) {
-                    Timber.e("blocked bolus with different volume amount $initiateBolusRequest vs $dataStoreUnits")
-                    runOnUiThread {
+                    val dataStoreUnits = dataStore.bolusFinalParameters.value?.units
+                    val initiateBolusRequest = withContext(Dispatchers.Default) {
+                        val confirmedBolus = InitiateConfirmedBolusSerializer.fromBytes("IGNORED_BY_WEAR", messageEvent.data)
+                        confirmedBolus.right as InitiateBolusRequest
+                    }
+
+                    if (initiateBolusRequest.totalVolume != InsulinUnit.from1To1000(dataStoreUnits)) {
+                        Timber.e("blocked bolus with different volume amount $initiateBolusRequest vs $dataStoreUnits")
                         navController.navigate(Screen.BolusBlocked.route)
+                        return@launch
                     }
-                    return
-                }
 
-                Timber.i("sending initiate-confirmed-bolus from wearable to phone")
-                sendMessage("/to-phone/initiate-confirmed-bolus", messageEvent.data)
+                    Timber.i("sending initiate-confirmed-bolus from wearable to phone")
+                    sendMessage("/to-phone/initiate-confirmed-bolus", messageEvent.data)
+                }
             }
             "/to-wear/blocked-bolus-signature" -> {
                 Timber.w("blocked bolus signature")
@@ -627,26 +632,34 @@ class MainActivity : ComponentActivity(), MessageClient.OnMessageReceivedListene
                 dataStore.connectionStatus.value = "Error: ${String(messageEvent.data)}"
             }
             "/from-pump/receive-qualifying-event" -> {
-                val pumpEvents = PumpQualifyingEventsSerializer.fromBytes(messageEvent.data)
-                onPumpQualifyingEventReceived(pumpEvents)
+                uiScope.launch {
+                    val pumpEvents = withContext(Dispatchers.Default) {
+                        PumpQualifyingEventsSerializer.fromBytes(messageEvent.data)
+                    }
+                    onPumpQualifyingEventReceived(pumpEvents)
+                }
             }
             "/from-pump/receive-message" -> {
-                if (inWaitingState()) {
-                    runOnUiThread {
+                uiScope.launch {
+                    if (inWaitingState()) {
                         navController.navigateClearBackStack(initialRoute)
                     }
+                    val pumpMessage = withContext(Dispatchers.Default) {
+                        PumpMessageSerializer.fromBytes(messageEvent.data)
+                    }
+                    onPumpMessageReceived(pumpMessage, false)
                 }
-                val pumpMessage = PumpMessageSerializer.fromBytes(messageEvent.data)
-                onPumpMessageReceived(pumpMessage, false)
             }
             "/from-pump/receive-cached-message" -> {
-                if (inWaitingState()) {
-                    runOnUiThread {
+                uiScope.launch {
+                    if (inWaitingState()) {
                         navController.navigateClearBackStack(initialRoute)
                     }
+                    val pumpMessage = withContext(Dispatchers.Default) {
+                        PumpMessageSerializer.fromBytes(messageEvent.data)
+                    }
+                    onPumpMessageReceived(pumpMessage, true)
                 }
-                val pumpMessage = PumpMessageSerializer.fromBytes(messageEvent.data)
-                onPumpMessageReceived(pumpMessage, true)
             }
             else -> {
                 Timber.w("wear activity unhandled receive: ${messageEvent.path} ${String(messageEvent.data)}")

--- a/wear/src/main/java/com/jwoglom/controlx2/PhoneCommService.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/PhoneCommService.kt
@@ -35,6 +35,12 @@ import com.jwoglom.pumpx2.pump.messages.models.InsulinUnit
 import com.jwoglom.pumpx2.pump.messages.response.currentStatus.ControlIQIOBResponse
 import com.jwoglom.pumpx2.pump.messages.response.currentStatus.CurrentBatteryAbstractResponse
 import com.jwoglom.pumpx2.pump.messages.response.currentStatus.CurrentEGVGuiDataResponse
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.time.Instant
 
@@ -45,6 +51,7 @@ class PhoneCommService : Service() {
 
     private lateinit var messageBus: MessageBus
     private val notificationManagerCompat: NotificationManagerCompat by lazy { NotificationManagerCompat.from(this) }
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
     override fun onCreate() {
         super.onCreate()
@@ -144,8 +151,12 @@ class PhoneCommService : Service() {
                     .putExtra("route", Screen.BolusNotEnabled.route)
             }
             "/to-wear/service-receive-message" -> {
-                val pumpMessage = PumpMessageSerializer.fromBytes(data)
-                onPumpMessageReceived(pumpMessage, false)
+                serviceScope.launch {
+                    val pumpMessage = withContext(Dispatchers.Default) {
+                        PumpMessageSerializer.fromBytes(data)
+                    }
+                    onPumpMessageReceived(pumpMessage, false)
+                }
             }
             "/to-wear/glucose-unit" -> {
                 val unitName = String(data)
@@ -156,6 +167,11 @@ class PhoneCommService : Service() {
                 }
             }
         }
+    }
+
+    override fun onDestroy() {
+        serviceScope.cancel()
+        super.onDestroy()
     }
 
     // keep in sync with CommService.PumpCommHandler#onReceiveMessage to ensure messages are sent


### PR DESCRIPTION
### Motivation
- Reduce main-thread work by moving expensive message deserialization and transformation off the UI thread while keeping navigation and user-visible state updates on the main dispatcher.
- Prevent UI jank and avoid lifecycle leaks by using coroutine scopes tied to the activity/service lifecycle.

### Description
- Added a lifecycle-scoped coroutine scope in `MainActivity` using `SupervisorJob() + Dispatchers.Main.immediate` and cancel it in `onDestroy()` to avoid leaks.
- For the `/to-wear/initiate-confirmed-bolus` path, moved `InitiateConfirmedBolusSerializer.fromBytes(...)` and request extraction to `Dispatchers.Default` via `withContext`, while keeping route checks and navigation on the main dispatcher.
- For `/from-pump/receive-qualifying-event`, `/from-pump/receive-message`, and `/from-pump/receive-cached-message`, perform parsing on `Dispatchers.Default` and then apply UI/state updates on the main dispatcher using the activity scope.
- Added a `serviceScope` to `PhoneCommService` (`SupervisorJob() + Dispatchers.Main.immediate`), moved `/to-wear/service-receive-message` deserialization into `Dispatchers.Default` via `withContext`, and cancel the scope in `onDestroy()`.

### Testing
- Attempted compilation with `./gradlew :wear:compileDebugKotlin --console=plain`; the build could not complete in this environment because the Android SDK location was not available (`SDK location not found` pointing to `/opt/android-sdk`), so compilation could not be validated here.
- No additional automated tests were executed in this environment due to the SDK/tooling constraint. Please run `./gradlew :wear:compileDebugKotlin` and the app instrumentation/unit tests on a development machine with the Android SDK present to fully validate behavior and threading correctness.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a52b2b67b0832caffa2453964e7ed4)