### PR TITLE
docs: add container-ready Android SDK bootstrap steps to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,33 +21,46 @@ This document summarizes the structure, design, and common workflows inside the 
   - `./gradlew :shared:lintDebug` runs lint on the shared code; `:mobile:lintDebug` and `:wear:lintDebug` catch Compose/manifest issues for each app.
   - `./gradlew testDebugUnitTest` executes JVM unit tests across modules (there are few today, but the task guards against regressions when new ones are added).
   - `./gradlew :mobile:connectedDebugAndroidTest` (or `:wear:connectedDebugAndroidTest`) runs instrumentation tests; requires an attached device/emulator with the service enabled.
-- Command-line prerequisites when running inside the Codex container:
-  1. Install the Android command-line tools into `/opt/android-sdk`:
+- Command-line prerequisites when running inside the Codex container (fixes `SDK location not found` failures):
+  1. Install Android command-line tools into `/opt/android-sdk` (safe to rerun):
      ```bash
+     set -euo pipefail
      cd /opt
      mkdir -p android-sdk
      cd android-sdk
-     wget https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip
-     unzip commandlinetools-linux-11076708_latest.zip
+     wget -q https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip -O cmdline-tools.zip
+     rm -rf cmdline-tools cmdline-tools_tmp
+     unzip -q -o cmdline-tools.zip
      mv cmdline-tools cmdline-tools_tmp
      mkdir -p cmdline-tools/latest
      mv cmdline-tools_tmp/* cmdline-tools/latest/
-     rm -rf cmdline-tools_tmp commandlinetools-linux-11076708_latest.zip
+     rm -rf cmdline-tools_tmp cmdline-tools.zip
      ```
-  2. Install the required SDK packages and accept licenses:
+  2. Export SDK env vars, then accept licenses:
      ```bash
      export ANDROID_SDK_ROOT=/opt/android-sdk
      export ANDROID_HOME=/opt/android-sdk
-     yes | /opt/android-sdk/cmdline-tools/latest/bin/sdkmanager --install \
-       "platform-tools" "platforms;android-35" "build-tools;35.0.0"
-     yes | /opt/android-sdk/cmdline-tools/latest/bin/sdkmanager --licenses
+     yes | /opt/android-sdk/cmdline-tools/latest/bin/sdkmanager --sdk_root=/opt/android-sdk --licenses || true
      ```
-  3. Ensure a `local.properties` file exists in the repo root (it is git-ignored) pointing at the SDK and keeping remote PumpX2 artifacts enabled:
+     Notes:
+     - `sdkmanager` may return exit code `141` after piped `yes`; if output ends with `All SDK package licenses accepted`, continue.
+     - To avoid the `141` status entirely, run `sdkmanager --licenses` interactively and answer `y`.
+  3. Install required platform packages:
+     ```bash
+     /opt/android-sdk/cmdline-tools/latest/bin/sdkmanager --sdk_root=/opt/android-sdk --install \
+       "platform-tools" "platforms;android-35" "build-tools;35.0.0"
+     ```
+  4. Ensure a `local.properties` file exists in the repo root (git-ignored) pointing at the installed SDK and keeping remote PumpX2 artifacts enabled:
      ```properties
      sdk.dir=/opt/android-sdk
      use_local_pumpx2=false
      ```
-  4. Run tests from the repo root with `./gradlew testDebugUnitTest --console=plain`. The `--console=plain` flag avoids spinner output that can overflow the execution log.
+  5. Validate with a module compile, then run broader checks:
+     ```bash
+     ./gradlew :wear:compileDebugKotlin --console=plain
+     ./gradlew testDebugUnitTest --console=plain
+     ```
+     The `--console=plain` flag avoids spinner output that can overflow execution logs.
 - Compose previews are heavily relied upon for iteration. Use `setUpPreviewState` (mobile) or the preview helpers inside wear UI files to seed fake data—this prevents Compose previews from crashing when new observable fields are introduced.
 - When PumpX2 artifacts change, clear Gradle caches with `./gradlew --stop && ./gradlew clean` or `./gradlew build --refresh-dependencies` before rebuilding so the new protocol definitions flow through to both apps.
 
@@ -189,4 +202,3 @@ This document summarizes the structure, design, and common workflows inside the 
 - Bolus/Temp rate windows manage raw user input via dedicated `MutableLiveData` fields (`bolusUnitsRawValue`, etc.). If you introduce new modal workflows, model them similarly so that state survives recomposition and can be reset cleanly when the modal closes.
 - Respect the message throttling/caching logic (`CacheSeconds`, `lastResponseMessage` map). Clearing the cache too aggressively can increase BLE load and battery consumption.
 - `HistoryLogFetcher` uses coroutines with `Mutex` to serialize fetch ranges. If you adjust fetch sizes/timeouts, update the constants (`InitialHistoryLogCount`, `FetchGroupTimeoutMs`) thoughtfully.
-


### PR DESCRIPTION
### Motivation
- The Codex container was failing Gradle builds due to a missing `/opt/android-sdk`, so the agent-added instructions provide a reproducible SDK bootstrap and license flow for container-based builds.
- The change documents a known `sdkmanager` quirk (piped `yes` sometimes returns exit code `141`) so future agents won't treat that as a fatal failure.

### Description
- Expanded the Command-line prerequisites in `AGENTS.md` with a step-by-step, safe-to-rerun script to download/unpack Android command-line tools into `/opt/android-sdk` and place them under `cmdline-tools/latest`.
- Added explicit guidance to export `ANDROID_SDK_ROOT`/`ANDROID_HOME`, accept SDK licenses (with a note about the `141` exit-code edge case), and install `platform-tools`, `platforms;android-35`, and `build-tools;35.0.0` via `sdkmanager`.
- Added a reminder to create a repo-local `local.properties` with `sdk.dir=/opt/android-sdk` and `use_local_pumpx2=false`, and to validate the setup with a module compile followed by unit tests.

### Testing
- Downloaded and unpacked the command-line tools into `/opt/android-sdk` successfully using `wget` + `unzip` (succeeds in the container).
- Accepted SDK licenses using `yes | /opt/android-sdk/cmdline-tools/latest/bin/sdkmanager --sdk_root=/opt/android-sdk --licenses` and noted the non-fatal `141` exit behavior while confirming the output contained `All SDK package licenses accepted`.
- Installed required SDK packages with `/opt/android-sdk/cmdline-tools/latest/bin/sdkmanager --sdk_root=/opt/android-sdk --install "platform-tools" "platforms;android-35" "build-tools;35.0.0"`, which succeeded.
- Validated the changes by running `./gradlew :wear:compileDebugKotlin --console=plain`, which completed successfully in the prepared environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6737ce86c832c88e8c3f0e0faf70e)