### PR TITLE
Clean up LastConnectionUpdatedTimestamp state observations

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/components/LastConnectionUpdatedTimestamp.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/components/LastConnectionUpdatedTimestamp.kt
@@ -10,13 +10,11 @@ import androidx.compose.runtime.setValue
 import com.jwoglom.controlx2.LocalDataStore
 import com.jwoglom.controlx2.shared.presentation.intervalOf
 import com.jwoglom.controlx2.shared.util.shortTimeAgo
-import timber.log.Timber
 
 @Composable
 fun LastConnectionUpdatedTimestamp() {
     val ds = LocalDataStore.current
 
-    val setupStage = ds.pumpSetupStage.observeAsState()
     val pumpConnected = ds.pumpConnected.observeAsState()
     val pumpLastConnectionTimestamp = ds.pumpLastConnectionTimestamp.observeAsState()
     val pumpLastMessageTimestamp = ds.pumpLastMessageTimestamp.observeAsState()
@@ -29,7 +27,7 @@ fun LastConnectionUpdatedTimestamp() {
         //Timber.d("set pumpLastMessageTimestampRelative=%s", pumpLastMessageTimestampRelative)
     }
 
-    LaunchedEffect (pumpConnected.value, pumpLastMessageTimestamp.value) {
+    LaunchedEffect (pumpLastMessageTimestamp.value) {
         updatePumpLastMessageTsRelative()
     }
 


### PR DESCRIPTION
### Motivation
- Simplify the composable by removing an unused observed state and ensure `LaunchedEffect` keys match only the values that affect rendering to avoid unnecessary recompositions.

### Description
- Removed `val setupStage = ds.pumpSetupStage.observeAsState()` and the unused `Timber` import, kept only `pumpConnected`, `pumpLastConnectionTimestamp`, and `pumpLastMessageTimestamp` observations, and simplified the `LaunchedEffect` to key on `pumpLastMessageTimestamp.value` while preserving the interval-based refresh in `LastConnectionUpdatedTimestamp.kt`.

### Testing
- Attempted `./gradlew :mobile:compileDebugKotlin --console=plain`, but the build cannot complete in this environment because `local.properties` (Android SDK path) is missing; the change is minimal and should compile normally in a configured Android build environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a931011f50832ca3f6f0dc05a8c4d4)