### PR TITLE
Refactor Control‑IQ state: remove unused observer and derive summary text

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/ControlIQSettingsActions.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/ControlIQSettingsActions.kt
@@ -86,12 +86,26 @@ fun ControlIQSettingsActions(
     val context = LocalContext.current
     val ds = LocalDataStore.current
 
-    val controlIQInfo = ds.controlIQInfoResponse.observeAsState()
     val controlIQEnabled = ds.controlIQEnabled.observeAsState()
     val controlIQWeight = ds.controlIQWeight.observeAsState()
     val controlIQWeightUnit = ds.controlIQWeightUnit.observeAsState()
     val controlIQTotalDailyInsulin = ds.controlIQTotalDailyInsulin.observeAsState()
     val sleepSchedule = ds.controlIQSleepScheduleResponse.observeAsState()
+
+    val controlIQSummaryText = remember(
+        controlIQEnabled.value,
+        controlIQWeight.value,
+        controlIQWeightUnit.value,
+        controlIQTotalDailyInsulin.value,
+    ) {
+        if (controlIQEnabled.value == null) {
+            "Loading..."
+        } else {
+            "Status: ${if (controlIQEnabled.value == true) "Enabled" else "Disabled"}\n" +
+                "Weight: ${controlIQWeight.value ?: "?"} ${controlIQWeightUnit.value ?: ""}\n" +
+                "Total Daily Insulin: ${controlIQTotalDailyInsulin.value ?: "?"} units"
+        }
+    }
 
     val refreshScope = rememberCoroutineScope()
     var refreshing by remember { mutableStateOf(true) }
@@ -215,15 +229,7 @@ fun ControlIQSettingsActions(
                     ListItem(
                         headlineContent = { Text("Control-IQ") },
                         supportingContent = {
-                            if (controlIQEnabled.value != null) {
-                                Text(
-                                    "Status: ${if (controlIQEnabled.value == true) "Enabled" else "Disabled"}\n" +
-                                    "Weight: ${controlIQWeight.value ?: "?"} ${controlIQWeightUnit.value ?: ""}\n" +
-                                    "Total Daily Insulin: ${controlIQTotalDailyInsulin.value ?: "?"} units"
-                                )
-                            } else {
-                                Text("Loading...")
-                            }
+                            Text(controlIQSummaryText)
                         },
                         leadingContent = { Icon(Icons.Filled.Settings, contentDescription = null) },
                         modifier = Modifier.clickable {


### PR DESCRIPTION
### Motivation
- Remove an unused `controlIQInfoResponse` observation and compute the Control‑IQ summary text from only the observed values to avoid dead observers and make UI derivation explicit.

### Description
- Removed `val controlIQInfo = ds.controlIQInfoResponse.observeAsState()`, added a `controlIQSummaryText` derived via `remember(...)` keyed on `controlIQEnabled`, `controlIQWeight`, `controlIQWeightUnit`, and `controlIQTotalDailyInsulin`, replaced the inline supporting text with `Text(controlIQSummaryText)`, and kept the DataStore alias as `val ds` while ensuring remaining observed fields are consumed by UI or effects.

### Testing
- Attempted `./gradlew :mobile:compileDebugKotlin --console=plain` but the build could not run in this environment because `local.properties` is missing (SDK location), so compilation verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a93102b5f0832c8eaf0e5c4eb048a5)