### PR TITLE
Remove unused DataStore observers from Landing composable

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/Landing.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/Landing.kt
@@ -115,10 +115,7 @@ fun Landing(
     val ds = LocalDataStore.current
     val coroutineScope = rememberCoroutineScope()
 
-    val setupStage = ds.pumpSetupStage.observeAsState()
     val pumpConnected = ds.pumpConnected.observeAsState()
-    val pumpLastConnectionTimestamp = ds.pumpLastConnectionTimestamp.observeAsState()
-    val pumpLastMessageTimestamp = ds.pumpLastMessageTimestamp.observeAsState()
     val deviceName = ds.setupDeviceName.observeAsState()
     val notificationBundle = ds.notificationBundle.observeAsState()
 


### PR DESCRIPTION
### Motivation
- Clean up unused state observers in the `Landing` composable to reduce unused variables and related warnings.

### Description
- Removed unused `DataStore` observers `setupStage`, `pumpLastConnectionTimestamp`, and `pumpLastMessageTimestamp` from `Landing.kt` and fixed EOF newline.

### Testing
- Built the Android project with `./gradlew assembleDebug` and ran unit tests with `./gradlew test`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a930fd7fd4832ca727d3f6f938be77)