### PR TITLE
TopText owns CGM LiveData; refactor CurrentCGMText to take plain values

### DIFF
--- a/wear/src/main/java/com/jwoglom/controlx2/presentation/components/CurrentCGMText.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/presentation/components/CurrentCGMText.kt
@@ -2,7 +2,6 @@ package com.jwoglom.controlx2.presentation.components
 
 import androidx.compose.foundation.background
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
@@ -16,7 +15,6 @@ import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.curvedText
 import com.google.common.base.Strings
-import com.jwoglom.controlx2.LocalDataStore
 import com.jwoglom.controlx2.presentation.defaultTheme
 import com.jwoglom.controlx2.presentation.redTheme
 import com.jwoglom.controlx2.shared.enums.GlucoseUnit
@@ -24,28 +22,26 @@ import com.jwoglom.controlx2.shared.util.GlucoseConverter
 
 @Composable
 fun CurrentCGMText(
+    cgmSessionState: String?,
+    cgmStatusText: String?,
+    cgmReading: Int?,
+    cgmDeltaArrow: String?,
+    cgmHighLowState: String?,
+    glucoseUnit: GlucoseUnit = GlucoseUnit.MGDL,
     textStyle: TextStyle? = null,
 ) {
-    val ds = LocalDataStore.current
-    val cgmSessionState = ds.cgmSessionState.observeAsState()
-    val cgmReading = ds.cgmReading.observeAsState()
-    val cgmDelta = ds.cgmDelta.observeAsState()
-    val cgmStatusText = ds.cgmStatusText.observeAsState()
-    val cgmHighLowState = ds.cgmHighLowState.observeAsState()
-    val cgmDeltaArrow = ds.cgmDeltaArrow.observeAsState()
-    val glucoseUnit = ds.glucoseUnitPreference.observeAsState()
-    val displayText = when (cgmSessionState.value) {
-        "Starting", "Stopped", "Stopping", "Unknown" -> cgmStatusText.value!!
+    val displayText = when (cgmSessionState) {
+        "Starting", "Stopped", "Stopping", "Unknown" -> cgmStatusText!!
         else -> when {
-            !Strings.isNullOrEmpty(cgmStatusText.value) -> cgmStatusText.value!!
+            !Strings.isNullOrEmpty(cgmStatusText) -> cgmStatusText!!
             else -> when {
-                cgmReading.value != null && cgmDeltaArrow.value != null -> "${GlucoseConverter.format(cgmReading.value!!, glucoseUnit.value ?: GlucoseUnit.MGDL)} ${cgmDeltaArrow.value}"
-                cgmReading.value != null -> GlucoseConverter.format(cgmReading.value!!, glucoseUnit.value ?: GlucoseUnit.MGDL)
+                cgmReading != null && cgmDeltaArrow != null -> "${GlucoseConverter.format(cgmReading, glucoseUnit)} ${cgmDeltaArrow}"
+                cgmReading != null -> GlucoseConverter.format(cgmReading, glucoseUnit)
                 else -> ""
             }
         }
     }
-    val primaryColor = when (cgmHighLowState.value) {
+    val primaryColor = when (cgmHighLowState) {
         "HIGH" -> redTheme.colors.secondary
         "LOW" -> redTheme.colors.primary
         else -> MaterialTheme.colors.primary
@@ -63,27 +59,24 @@ fun CurrentCGMText(
 
 @Composable
 fun CurrentCGMTextDeltaArrow(
+    cgmSessionState: String?,
+    cgmStatusText: String?,
+    cgmDeltaArrow: String?,
+    cgmHighLowState: String?,
     textStyle: TextStyle? = null,
     modifier: Modifier = Modifier,
 ) {
-    val ds = LocalDataStore.current
-    val cgmSessionState = ds.cgmSessionState.observeAsState()
-    val cgmReading = ds.cgmReading.observeAsState()
-    val cgmDelta = ds.cgmDelta.observeAsState()
-    val cgmStatusText = ds.cgmStatusText.observeAsState()
-    val cgmHighLowState = ds.cgmHighLowState.observeAsState()
-    val cgmDeltaArrow = ds.cgmDeltaArrow.observeAsState()
-    val displayText = when (cgmSessionState.value) {
+    val displayText = when (cgmSessionState) {
         "Starting", "Stopped", "Stopping", "Unknown" -> ""
         else -> when {
-            !Strings.isNullOrEmpty(cgmStatusText.value) -> ""
+            !Strings.isNullOrEmpty(cgmStatusText) -> ""
             else -> when {
-                cgmDeltaArrow.value != null -> "${cgmDeltaArrow.value}"
+                cgmDeltaArrow != null -> "${cgmDeltaArrow}"
                 else -> ""
             }
         }
     }
-    val primaryColor = when (cgmHighLowState.value) {
+    val primaryColor = when (cgmHighLowState) {
         "HIGH" -> redTheme.colors.secondary
         "LOW" -> redTheme.colors.primary
         else -> defaultTheme.colors.primary

--- a/wear/src/main/java/com/jwoglom/controlx2/presentation/components/TopText.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/presentation/components/TopText.kt
@@ -48,7 +48,6 @@ fun TopText(
         val ds = LocalDataStore.current
         val cgmSessionState = ds.cgmSessionState.observeAsState()
         val cgmReading = ds.cgmReading.observeAsState()
-        val cgmDelta = ds.cgmDelta.observeAsState()
         val cgmStatusText = ds.cgmStatusText.observeAsState()
         val cgmHighLowState = ds.cgmHighLowState.observeAsState()
         val cgmDeltaArrow = ds.cgmDeltaArrow.observeAsState()
@@ -83,11 +82,25 @@ fun TopText(
                     glucoseUnit.value ?: GlucoseUnit.MGDL
                 )
                 curvedComposable (radialAlignment = CurvedAlignment.Radial.Outer) {
-                    CurrentCGMTextDeltaArrow(textStyle, modifier = Modifier.padding(start = 2.dp))
+                    CurrentCGMTextDeltaArrow(
+                        cgmSessionState = cgmSessionState.value,
+                        cgmStatusText = cgmStatusText.value,
+                        cgmDeltaArrow = cgmDeltaArrow.value,
+                        cgmHighLowState = cgmHighLowState.value,
+                        textStyle = textStyle,
+                        modifier = Modifier.padding(start = 2.dp)
+                    )
                 }
             },
             endLinearContent = {
-                CurrentCGMText()
+                CurrentCGMText(
+                    cgmSessionState = cgmSessionState.value,
+                    cgmStatusText = cgmStatusText.value,
+                    cgmReading = cgmReading.value,
+                    cgmDeltaArrow = cgmDeltaArrow.value,
+                    cgmHighLowState = cgmHighLowState.value,
+                    glucoseUnit = glucoseUnit.value ?: GlucoseUnit.MGDL
+                )
             }
         )
     }


### PR DESCRIPTION
### Motivation
- Prevent duplicate LiveData subscriptions in the top bar by making `TopText` the single owner of CGM observations and passing plain values to renderers.
- Remove an unused `cgmDelta.observeAsState()` and eliminate redundant observers to reduce recompositions and potential inconsistencies.
- Keep the existing curved and linear time/CGM rendering behavior unchanged while simplifying ownership.
- Use the `ds` alias for the DataStore instance in `TopText` to match project conventions.

### Description
- `TopText.kt`: `TopText` now observes CGM LiveData once via `ds = LocalDataStore.current` and `observeAsState()` for the needed fields and no longer observes `cgmDelta`; it forwards plain values into the trailing curved/linear renderers.
- `CurrentCGMText.kt`: `CurrentCGMText` and `CurrentCGMTextDeltaArrow` were refactored to accept plain parameters (`cgmSessionState`, `cgmStatusText`, `cgmReading`, `cgmDeltaArrow`, `cgmHighLowState`, `glucoseUnit`) instead of calling `LocalDataStore` and `observeAsState()` internally.
- The curved helper `currentCGMTextCurvedExcludingDeltaArrow` continues to accept the same plain values, preserving existing text and color decision logic.
- Removed duplicate LiveData subscriptions for `cgmSessionState`, `cgmReading`, `cgmStatusText`, `cgmHighLowState`, `cgmDeltaArrow`, and `glucoseUnitPreference`, and kept `ds` as the DataStore alias in `TopText`.

### Testing
- Ran `rg`/inspection to locate usages and ensure `CurrentCGMText`/`CurrentCGMTextDeltaArrow` are only called from `TopText`, which succeeded.
- Attempted an automated Kotlin compile using `./gradlew :wear:compileDebugKotlin --console=plain`, which failed in this environment because the Android SDK location is not available (`SDK location not found`), so compilation could not be validated here.
- Added a `local.properties` file and re-ran the compile attempt, which still failed due to the container not having a valid `/opt/android-sdk`, so runtime compilation was not completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9310aa9b0832cb196ec7b7f98d3c8)