### PR TITLE
Fix cache age calculation and always populate bolus calc snapshot

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/CommService.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/CommService.kt
@@ -606,7 +606,7 @@ class CommService : Service() {
                     PumpMessageSerializer.fromBulkBytes(msg.obj as ByteArray).forEach {
                         if (lastResponseMessage.containsKey(Pair(it.characteristic, it.responseOpCode)) && !isBolusCommand(it)) {
                             val response = lastResponseMessage.get(Pair(it.characteristic, it.responseOpCode))
-                            val ageSeconds = Duration.between(Instant.now(), response?.second).seconds
+                            val ageSeconds = Duration.between(response?.second, Instant.now()).seconds
                             if (ageSeconds <= CacheSeconds) {
                                 Timber.i("pumpCommHandler cached hit: $response")
                                 sendWearCommMessage(

--- a/wear/src/main/java/com/jwoglom/controlx2/MainActivity.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/MainActivity.kt
@@ -460,9 +460,7 @@ class MainActivity : ComponentActivity(), MessageClient.OnMessageReceivedListene
                 UpdateComplication(applicationContext, WearX2Complication.CGM_READING)
             }
             is BolusCalcDataSnapshotResponse -> {
-                if (!cached) {
-                    dataStore.bolusCalcDataSnapshot.value = message
-                }
+                dataStore.bolusCalcDataSnapshot.value = message
                 dataStore.maxCarbAmount.value = (InsulinUnit.from1000To1(message.maxBolusAmount.toLong()) * InsulinUnit.from1000To1(message.carbRatio)).roundToInt()
             }
             is LastBGResponse -> {


### PR DESCRIPTION
### Motivation
- Fix incorrect cache age computation that could mark recent pump responses as expired due to reversed `Duration.between` arguments.
- Ensure the bolus calculation snapshot is always pushed into the data store so UI/state is updated even for messages flagged as cached.

### Description
- In `CommService.kt` correct the cache age calculation by changing `Duration.between(Instant.now(), response?.second).seconds` to `Duration.between(response?.second, Instant.now()).seconds` so `ageSeconds` is calculated correctly.
- In `MainActivity.kt` remove the conditional that skipped assigning `dataStore.bolusCalcDataSnapshot.value` when `cached` was true so the snapshot is always updated; the `maxCarbAmount` computation remains unchanged.

### Testing
- Ran unit tests with `./gradlew test`, and the test suite completed successfully.
- Built the debug app with `./gradlew assembleDebug`, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a72b37ebf8832c9bf297b4a5e8eb51)