### PR TITLE
Refactor Landing bottom sheet resets out of composition branches

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/Landing.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/Landing.kt
@@ -46,6 +46,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
@@ -125,6 +126,15 @@ fun Landing(
         bottomSheetState = BottomSheetState(bottomScaffoldDisplayState, density=Density(context))
     )
     var bottomScaffoldState by remember { mutableStateOf(_bottomScaffoldState) }
+
+    LaunchedEffect(bottomScaffoldState) {
+        if (bottomScaffoldState != BottomScaffoldState.BOLUS_WINDOW) {
+            resetBolusDataStoreState(ds)
+        }
+        if (bottomScaffoldState != BottomScaffoldState.TEMP_RATE_WINDOW) {
+            resetTempRateDataStoreState(ds)
+        }
+    }
 
     fun showBottomScaffold(): Boolean {
         return displayBottomScaffold.bottomSheetState.isExpanded ||
@@ -208,13 +218,11 @@ fun Landing(
                                         closeWindow = {
                                             coroutineScope.launch {
                                                 displayBottomScaffold.bottomSheetState.collapse()
-                                                resetBolusDataStoreState(dataStore)
+                                                resetBolusDataStoreState(ds)
                                                 bottomScaffoldState = BottomScaffoldState.NONE
                                             }
                                         }
                                     )
-                                } else {
-                                    resetBolusDataStoreState(dataStore)
                                 }
                                 if (bottomScaffoldState == BottomScaffoldState.TEMP_RATE_WINDOW) {
                                     TempRateWindow(
@@ -223,12 +231,10 @@ fun Landing(
                                             coroutineScope.launch {
                                                 displayBottomScaffold.bottomSheetState.collapse()
                                                 bottomScaffoldState = BottomScaffoldState.NONE
-                                                resetTempRateDataStoreState(dataStore)
+                                                resetTempRateDataStoreState(ds)
                                             }
                                         }
                                     )
-                                } else {
-                                    resetTempRateDataStoreState(dataStore)
                                 }
                             }
                             item {


### PR DESCRIPTION
### Motivation
- Avoid mutating DataStore during passive composition which caused `resetBolusDataStoreState(...)` and `resetTempRateDataStoreState(...)` to run repeatedly on recomposition.
- Move reset logic into event/effect boundaries so resets occur on intentional state transitions rather than during rendering.

### Description
- Added a `LaunchedEffect(bottomScaffoldState)` to `Landing` that resets bolus/temp-rate state when the active bottom-sheet state is not the corresponding window.
- Removed direct `resetBolusDataStoreState(...)` and `resetTempRateDataStoreState(...)` calls from the passive `else` branches inside `sheetContent` so no state mutation runs during composition.
- Kept reset behavior on explicit close callbacks and standardized usage of the local `ds` reference (`val ds = LocalDataStore.current`) when calling reset helpers.
- Added the `LaunchedEffect` import and updated `mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/Landing.kt` accordingly.

### Testing
- Attempted to compile the mobile module with `./gradlew :mobile:compileDebugKotlin --console=plain`, but the build failed in the container due to missing Android SDK location; a `local.properties` file was added but `/opt/android-sdk` is not present in this environment so compilation could not complete.
- The change was committed locally (`Move Landing sheet resets into effect/event boundaries`) and the modified file is `mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/Landing.kt`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa3a76c014832c8eecf859f918fda6)