### PR TITLE
Refactor Compose coroutine sleeps to cancellation-friendly delays

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/components/PumpSetupStageDescription.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/components/PumpSetupStageDescription.kt
@@ -49,9 +49,7 @@ import com.jwoglom.pumpx2.pump.PumpState
 import com.jwoglom.pumpx2.pump.bluetooth.PumpReadyState
 import com.jwoglom.pumpx2.pump.messages.models.KnownDeviceModel
 import com.jwoglom.pumpx2.pump.messages.models.PairingCodeType
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 const val TroubleshootingStepsThresholdSeconds = 15

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/components/ServiceDisabledMessage.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/components/ServiceDisabledMessage.kt
@@ -28,9 +28,8 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import com.jwoglom.controlx2.LocalDataStore
 import com.jwoglom.controlx2.Prefs
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.delay
 import org.apache.commons.lang3.text.FormattableUtils.append
 
 @Composable
@@ -56,16 +55,12 @@ fun ServiceDisabledMessage(
                 modifier = Modifier.padding(8.dp).clickable {
                     Prefs(context).setServiceEnabled(true)
                     coroutineScope.launch {
-                        withContext(Dispatchers.IO) {
-                            Thread.sleep(250)
-                        }
+                        delay(250)
                         // reload service, if running
                         sendMessage("/to-phone/force-reload", "".toByteArray())
-                        withContext(Dispatchers.IO) {
-                            Thread.sleep(250)
-                            // reload main activity as fallback
-                            sendMessage("/to-phone/app-reload", "".toByteArray())
-                        }
+                        delay(250)
+                        // reload main activity as fallback
+                        sendMessage("/to-phone/app-reload", "".toByteArray())
                     }
                 }
             ) {

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/AppSetup.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/AppSetup.kt
@@ -46,9 +46,8 @@ import com.jwoglom.controlx2.presentation.navigation.Screen
 import com.jwoglom.controlx2.presentation.theme.ControlX2Theme
 import com.jwoglom.controlx2.shared.enums.GlucoseUnit
 import com.jwoglom.controlx2.shared.util.twoDecimalPlaces
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.delay
 
 @Composable
 fun AppSetup(
@@ -89,9 +88,7 @@ fun AppSetup(
                 onClick = {
                     Prefs(context).setAppSetupComplete(true)
                     coroutineScope.launch {
-                        withContext(Dispatchers.IO) {
-                            Thread.sleep(250)
-                        }
+                        delay(250)
                         sendMessage(
                             "/to-phone/app-reload",
                             "".toByteArray()
@@ -122,9 +119,7 @@ fun AppSetup(
                             connectionSharingEnabled = it
                             Prefs(context).setConnectionSharingEnabled(it)
                             coroutineScope.launch {
-                                withContext(Dispatchers.IO) {
-                                    Thread.sleep(250)
-                                }
+                                delay(250)
                                 sendMessage(
                                     "/to-phone/app-reload",
                                     "".toByteArray()
@@ -137,9 +132,7 @@ fun AppSetup(
                     connectionSharingEnabled = !connectionSharingEnabled
                     Prefs(context).setConnectionSharingEnabled(connectionSharingEnabled)
                     coroutineScope.launch {
-                        withContext(Dispatchers.IO) {
-                            Thread.sleep(250)
-                        }
+                        delay(250)
                         sendMessage(
                             "/to-phone/app-reload",
                             "".toByteArray()
@@ -167,9 +160,7 @@ fun AppSetup(
                                 insulinDeliveryActions = false
                                 Prefs(context).setInsulinDeliveryActions(false)
                                 coroutineScope.launch {
-                                    withContext(Dispatchers.IO) {
-                                        Thread.sleep(250)
-                                    }
+                                    delay(250)
                                     sendMessage(
                                         "/to-phone/app-reload",
                                         "".toByteArray()
@@ -186,9 +177,7 @@ fun AppSetup(
                         insulinDeliveryActions = false
                         Prefs(context).setInsulinDeliveryActions(false)
                         coroutineScope.launch {
-                            withContext(Dispatchers.IO) {
-                                Thread.sleep(250)
-                            }
+                            delay(250)
                             sendMessage(
                                 "/to-phone/app-reload",
                                 "".toByteArray()
@@ -323,9 +312,7 @@ fun AppSetup(
                                     // Sync glucose unit to wear app and trigger reload
                                     coroutineScope.launch {
                                         sendMessage("/to-wear/glucose-unit", unit.name.toByteArray())
-                                        withContext(Dispatchers.IO) {
-                                            Thread.sleep(250)
-                                        }
+                                        delay(250)
                                         sendMessage("/to-phone/app-reload", "".toByteArray())
                                     }
                                 }
@@ -364,9 +351,7 @@ fun AppSetup(
                     Prefs(context).setInsulinDeliveryActions(true)
                     showInsulinWarningDialog = false
                     coroutineScope.launch {
-                        withContext(Dispatchers.IO) {
-                            Thread.sleep(250)
-                        }
+                        delay(250)
                         sendMessage("/to-phone/app-reload", "".toByteArray())
                     }
                 }) {

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/PumpSetup.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/PumpSetup.kt
@@ -82,9 +82,8 @@ import com.jwoglom.pumpx2.pump.bluetooth.PumpReadyState
 import com.jwoglom.pumpx2.pump.messages.models.KnownDeviceModel
 import com.jwoglom.pumpx2.pump.messages.models.PairingCodeType
 import com.jwoglom.pumpx2.pump.messages.response.authentication.CentralChallengeResponse
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.delay
 import timber.log.Timber
 
 @Composable
@@ -118,16 +117,12 @@ fun PumpSetup(
         PumpState.setJpakeServerNonce(context, "")
         PumpState.setSavedBluetoothMAC(context, "")
         coroutineScope.launch {
-            withContext(Dispatchers.IO) {
-                Thread.sleep(500)
-            }
+            delay(500)
             sendMessage(
                 "/to-phone/app-reload",
                 "".toByteArray()
             )
-            withContext(Dispatchers.IO) {
-                Thread.sleep(500)
-            }
+            delay(500)
             navController?.navigate(Screen.PumpSetup.route)
         }
     }
@@ -316,9 +311,7 @@ fun PumpSetup(
                                                 pumpStateStatus =
                                                     "Success, application will reload with new state momentarily..."
                                                 coroutineScope.launch {
-                                                    withContext(Dispatchers.IO) {
-                                                        Thread.sleep(1000)
-                                                    }
+                                                    delay(1000)
                                                     triggerAppReload(context)
                                                 }
 

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Actions.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Actions.kt
@@ -77,10 +77,9 @@ import com.jwoglom.pumpx2.pump.messages.request.control.StopTempRateRequest
 import com.jwoglom.pumpx2.pump.messages.request.control.SuspendPumpingRequest
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.HomeScreenMirrorRequest
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.TempRateRequest
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.delay
 import timber.log.Timber
 
 @Composable
@@ -129,9 +128,7 @@ fun Actions(
                 sinceLastFetchTime = 0
             }
 
-            withContext(Dispatchers.IO) {
-                Thread.sleep(250)
-            }
+            delay(250)
             sinceLastFetchTime += 250
         }
         Timber.i("Actions loading done: ${actionsFields.map { it.value }}")
@@ -271,7 +268,7 @@ fun Actions(
                                             sendPumpCommands(SendType.BUST_CACHE, listOf(ResumePumpingRequest()))
                                             refreshScope.launch {
                                                 repeat(5) {
-                                                    Thread.sleep(1000)
+                                                    delay(1000)
                                                     sendPumpCommands(
                                                         SendType.BUST_CACHE,
                                                         listOf(HomeScreenMirrorRequest())
@@ -319,7 +316,7 @@ fun Actions(
                                             sendPumpCommands(SendType.BUST_CACHE, listOf(SuspendPumpingRequest()))
                                             refreshScope.launch {
                                                 repeat(5) {
-                                                    Thread.sleep(1000)
+                                                    delay(1000)
                                                     sendPumpCommands(
                                                         SendType.BUST_CACHE,
                                                         listOf(HomeScreenMirrorRequest())
@@ -405,7 +402,7 @@ fun Actions(
                                         // Refresh logic
                                         refreshScope.launch {
                                             repeat(5) {
-                                                Thread.sleep(1000)
+                                                delay(1000)
                                                 sendPumpCommands(
                                                     SendType.BUST_CACHE,
                                                     listOf(ControlIQInfoRequestBuilder.create(apiVersion()))
@@ -484,9 +481,7 @@ fun Actions(
 
                                         // Refresh logic
                                         refreshScope.launch {
-                                            withContext(Dispatchers.IO) {
-                                                Thread.sleep(250)
-                                            }
+                                            delay(250)
                                             sendPumpCommands(
                                                 SendType.BUST_CACHE,
                                                 listOf(ControlIQInfoRequestBuilder.create(apiVersion()))
@@ -576,9 +571,7 @@ fun Actions(
                                             refreshScope.launch {
                                                 showStopTempRateMenu = false
                                                 sendPumpCommands(SendType.BUST_CACHE, listOf(StopTempRateRequest()))
-                                                withContext(Dispatchers.IO) {
-                                                    Thread.sleep(250)
-                                                }
+                                                delay(250)
                                                 sendPumpCommands(
                                                     SendType.BUST_CACHE,
                                                     listOf(TempRateRequest())

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/BolusWindow.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/BolusWindow.kt
@@ -89,10 +89,8 @@ import com.jwoglom.controlx2.shared.util.snakeCaseToSpace
 import com.jwoglom.controlx2.shared.util.twoDecimalPlaces
 import com.jwoglom.controlx2.shared.util.twoDecimalPlaces1000Unit
 import com.jwoglom.pumpx2.pump.messages.bluetooth.PumpStateSupplier
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.util.function.Supplier
 
@@ -177,16 +175,12 @@ fun BolusWindow(
                 sinceLastFetchTime = 0
             }
 
-            withContext(Dispatchers.IO) {
-                Thread.sleep(250)
-            }
+            delay(250)
             sinceLastFetchTime += 250
         }
         Timber.i("BolusScreen base loading done: ${baseFields.map { it.value }}")
         if (sinceLastFetchTime == 0) {
-            withContext(Dispatchers.IO) {
-                Thread.sleep(250)
-            }
+            delay(250)
         }
         refreshing = false
     }

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/CGMActions.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/CGMActions.kt
@@ -71,10 +71,9 @@ import com.jwoglom.pumpx2.pump.messages.request.control.StopDexcomCGMSensorSessi
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.CGMStatusRequest
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.GetSavedG7PairingCodeRequest
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.HomeScreenMirrorRequest
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.delay
 import timber.log.Timber
 
 @Composable
@@ -126,9 +125,7 @@ fun CGMActions(
                 sinceLastFetchTime = 0
             }
 
-            withContext(Dispatchers.IO) {
-                Thread.sleep(250)
-            }
+            delay(250)
             sinceLastFetchTime += 250
         }
         Timber.i("Actions loading done: ${cgmActionsFields.map { it.value }}")
@@ -306,9 +303,7 @@ fun CGMActions(
 
                                                 run repeatBlock@{
                                                     repeat(3) {
-                                                        withContext(Dispatchers.IO) {
-                                                            Thread.sleep(250)
-                                                        }
+                                                        delay(250)
                                                         if (cgmSetupG6SensorCode.value == startG6CgmSessionInProgressTxId) {
                                                             return@repeatBlock
                                                         }
@@ -322,9 +317,7 @@ fun CGMActions(
                                                 ))
 
                                                 showStartG6CgmSessionMenu = false
-                                                withContext(Dispatchers.IO) {
-                                                    Thread.sleep(250)
-                                                }
+                                                delay(250)
                                                 sendPumpCommands(
                                                     SendType.BUST_CACHE,
                                                     listOf(CGMStatusRequest())
@@ -375,7 +368,7 @@ fun CGMActions(
 
                                                 showStopG6CgmSessionMenu = false
                                                 repeat(3) {
-                                                    Thread.sleep(250)
+                                                    delay(250)
                                                     sendPumpCommands(
                                                         SendType.BUST_CACHE,
                                                         listOf(CGMStatusRequest())
@@ -493,9 +486,7 @@ fun CGMActions(
 
                                                 run repeatBlock@{
                                                     repeat(3) {
-                                                        withContext(Dispatchers.IO) {
-                                                            Thread.sleep(250)
-                                                        }
+                                                        delay(250)
                                                         sendPumpCommands(
                                                             SendType.BUST_CACHE, listOf(
                                                                 GetSavedG7PairingCodeRequest()

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/CartridgeActions.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/CartridgeActions.kt
@@ -53,10 +53,9 @@ import com.jwoglom.pumpx2.pump.messages.request.currentStatus.CGMStatusRequest
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.HomeScreenMirrorRequest
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.TimeSinceResetRequest
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.UnknownMobiOpcode20Request
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.delay
 import timber.log.Timber
 
 private enum class CartridgeSubScreen {
@@ -116,7 +115,7 @@ fun CartridgeActions(
                 fetchDataStoreFields(SendType.CACHED)
                 sinceLastFetchTime = 0
             }
-            withContext(Dispatchers.IO) { Thread.sleep(250) }
+            delay(250)
             sinceLastFetchTime += 250
         }
         refreshing = false

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/ControlIQSettingsActions.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/ControlIQSettingsActions.kt
@@ -68,11 +68,9 @@ import com.jwoglom.pumpx2.pump.messages.request.control.ChangeControlIQSettingsR
 import com.jwoglom.pumpx2.pump.messages.request.control.SetSleepScheduleRequest
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.ControlIQSleepScheduleRequest
 import com.jwoglom.pumpx2.pump.messages.response.currentStatus.ControlIQSleepScheduleResponse
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 @Composable
@@ -130,9 +128,7 @@ fun ControlIQSettingsActions(
                 sinceLastFetchTime = 0
             }
 
-            withContext(Dispatchers.IO) {
-                Thread.sleep(250)
-            }
+            delay(250)
             sinceLastFetchTime += 250
         }
         Timber.i("ControlIQSettingsActions loading done: ${controlIQSettingsFields.map { it.value }}")

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Dashboard.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Dashboard.kt
@@ -70,10 +70,9 @@ import com.jwoglom.controlx2.shared.presentation.intervalOf
 import com.jwoglom.controlx2.shared.util.SendType
 import com.jwoglom.pumpx2.pump.messages.models.NotificationBundle
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.HistoryLogStatusRequest
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.delay
 import timber.log.Timber
 
 @Composable
@@ -110,9 +109,7 @@ fun Dashboard(
                 sinceLastFetchTime = 0
             }
 
-            withContext(Dispatchers.IO) {
-                Thread.sleep(250)
-            }
+            delay(250)
             sinceLastFetchTime += 250
         }
         Timber.i("Dashboard loading done: ${dashboardFields.map { it.value }}")

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Debug.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Debug.kt
@@ -137,10 +137,9 @@ import com.jwoglom.controlx2.shared.enums.GlucoseUnit
 import com.jwoglom.controlx2.shared.util.SendType
 import com.jwoglom.controlx2.shared.util.shortTimeAgo
 import com.jwoglom.pumpx2.pump.PumpState
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.delay
 import org.json.JSONArray
 import org.json.JSONObject
 import timber.log.Timber
@@ -551,9 +550,7 @@ fun Debug(
                                 if (dataStore.historyLogStatus.value != null) {
                                     break
                                 }
-                                withContext(Dispatchers.IO) {
-                                    Thread.sleep(100)
-                                }
+                                delay(100)
                             }
 
                             triggerHistoryLogRequestDialog(
@@ -766,9 +763,7 @@ fun Debug(
                             modifier = Modifier.clickable {
                                 Prefs(context).setOnlySnoopBluetoothEnabled(false)
                                 coroutineScope.launch {
-                                    withContext(Dispatchers.IO) {
-                                        Thread.sleep(250)
-                                    }
+                                    delay(250)
                                     sendMessage("/to-phone/force-reload", "".toByteArray())
                                 }
                             }
@@ -786,9 +781,7 @@ fun Debug(
                             modifier = Modifier.clickable {
                                 Prefs(context).setOnlySnoopBluetoothEnabled(true)
                                 coroutineScope.launch {
-                                    withContext(Dispatchers.IO) {
-                                        Thread.sleep(250)
-                                    }
+                                    delay(250)
                                     sendMessage("/to-phone/force-reload", "".toByteArray())
                                 }
                             }

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Notifications.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Notifications.kt
@@ -60,10 +60,9 @@ import com.jwoglom.pumpx2.pump.messages.Message
 import com.jwoglom.pumpx2.pump.messages.models.KnownDeviceModel
 import com.jwoglom.pumpx2.pump.messages.models.NotificationBundle
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.HomeScreenMirrorRequest
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.delay
 import timber.log.Timber
 
 @Composable
@@ -103,9 +102,7 @@ fun Notifications(
                 sinceLastFetchTime = 0
             }
 
-            withContext(Dispatchers.IO) {
-                Thread.sleep(250)
-            }
+            delay(250)
             sinceLastFetchTime += 250
         }
         Timber.i("Notifications loading done: ${notificationsFields.map { it.value }}")

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/ProfileActions.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/ProfileActions.kt
@@ -81,10 +81,9 @@ import com.jwoglom.pumpx2.pump.messages.builders.IDPManager
 import com.jwoglom.pumpx2.pump.messages.models.InsulinUnit
 import com.jwoglom.pumpx2.pump.messages.models.KnownDeviceModel
 import com.jwoglom.pumpx2.pump.messages.models.MinsTime
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.delay
 import timber.log.Timber
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -132,9 +131,7 @@ fun ProfileActions(
             }
 
             if (ds.idpManager.value == null) {
-                withContext(Dispatchers.IO) {
-                    Thread.sleep(250)
-                }
+                delay(250)
                 continue
             }
 
@@ -158,9 +155,7 @@ fun ProfileActions(
             }
 
 
-            withContext(Dispatchers.IO) {
-                Thread.sleep(250)
-            }
+            delay(250)
             sinceLastFetchTime += 250
         }
         Timber.i("profileActions loading done: ${ds.idpManager}")

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/SafetyLimitsActions.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/SafetyLimitsActions.kt
@@ -64,11 +64,9 @@ import com.jwoglom.pumpx2.pump.messages.request.control.SetMaxBolusLimitRequest
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.BasalLimitSettingsRequest
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.GlobalMaxBolusSettingsRequest
 import com.jwoglom.pumpx2.pump.messages.models.InsulinUnit
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 @Composable
@@ -108,9 +106,7 @@ fun SafetyLimitsActions(
                 sinceLastFetchTime = 0
             }
 
-            withContext(Dispatchers.IO) {
-                Thread.sleep(250)
-            }
+            delay(250)
             sinceLastFetchTime += 250
         }
         Timber.i("SafetyLimitsActions loading done: ${safetyLimitsFields.map { it.value }}")

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Settings.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Settings.kt
@@ -58,6 +58,7 @@ import com.jwoglom.pumpx2.pump.messages.request.control.PlaySoundRequest
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.delay
 import java.time.Instant
 
 @Composable
@@ -107,9 +108,7 @@ fun Settings(
                         modifier = Modifier.clickable {
                             Prefs(context).setServiceEnabled(false)
                             coroutineScope.launch {
-                                withContext(Dispatchers.IO) {
-                                    Thread.sleep(250)
-                                }
+                                delay(250)
                                 sendMessage("/to-phone/force-reload", "".toByteArray())
                             }
                         }
@@ -127,16 +126,12 @@ fun Settings(
                         modifier = Modifier.clickable {
                             Prefs(context).setServiceEnabled(true)
                             coroutineScope.launch {
-                                withContext(Dispatchers.IO) {
-                                    Thread.sleep(250)
-                                }
+                                delay(250)
                                 // reload service, if running
                                 sendMessage("/to-phone/force-reload", "".toByteArray())
-                                withContext(Dispatchers.IO) {
-                                    Thread.sleep(250)
-                                    // reload main activity as fallback
-                                    sendMessage("/to-phone/app-reload", "".toByteArray())
-                                }
+                                delay(250)
+                                // reload main activity as fallback
+                                sendMessage("/to-phone/app-reload", "".toByteArray())
                             }
                         }
                     )
@@ -158,7 +153,7 @@ fun Settings(
 //                            Prefs(context).setConnectionSharingEnabled(false)
 //                            coroutineScope.launch {
 //                                withContext(Dispatchers.IO) {
-//                                    Thread.sleep(250)
+//                                    delay(250)
 //                                }
 //                                sendMessage("/to-phone/force-reload", "".toByteArray())
 //                            }
@@ -178,7 +173,7 @@ fun Settings(
 //                            Prefs(context).setConnectionSharingEnabled(true)
 //                            coroutineScope.launch {
 //                                withContext(Dispatchers.IO) {
-//                                    Thread.sleep(250)
+//                                    delay(250)
 //                                }
 //                                sendMessage("/to-phone/force-reload", "".toByteArray())
 //                            }

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/SoundSettingsActions.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/SoundSettingsActions.kt
@@ -73,11 +73,9 @@ import com.jwoglom.pumpx2.pump.messages.request.control.SetPumpSoundsRequest
 import com.jwoglom.pumpx2.pump.messages.request.control.SetQuickBolusSettingsRequest
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.PumpGlobalsRequest
 import com.jwoglom.pumpx2.pump.messages.response.currentStatus.PumpGlobalsResponse
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 @Composable
@@ -117,9 +115,7 @@ fun SoundSettingsActions(
                 sinceLastFetchTime = 0
             }
 
-            withContext(Dispatchers.IO) {
-                Thread.sleep(250)
-            }
+            delay(250)
             sinceLastFetchTime += 250
         }
         Timber.i("SoundSettingsActions loading done: ${soundSettingsActionsFields.map { it.value }}")

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/TempRateWindow.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/TempRateWindow.kt
@@ -53,9 +53,8 @@ import com.jwoglom.pumpx2.pump.messages.Message
 import com.jwoglom.pumpx2.pump.messages.request.control.SetTempRateRequest
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.HomeScreenMirrorRequest
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.TempRateRequest
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.delay
 import timber.log.Timber
 
 @Composable
@@ -116,16 +115,12 @@ fun TempRateWindow(
                 sinceLastFetchTime = 0
             }
 
-            withContext(Dispatchers.IO) {
-                Thread.sleep(250)
-            }
+            delay(250)
             sinceLastFetchTime += 250
         }
         Timber.i("TempRateWindow base loading done: ${baseFields.map { it.value }}")
         if (sinceLastFetchTime == 0) {
-            withContext(Dispatchers.IO) {
-                Thread.sleep(250)
-            }
+            delay(250)
         }
         refreshing = false
     }
@@ -348,9 +343,7 @@ fun TempRateWindow(
                             closeWindow()
                         }
                         refreshScope.launch {
-                            withContext(Dispatchers.IO) {
-                                Thread.sleep(250)
-                            }
+                            delay(250)
                         }
                         refreshScope.launch {
                             sendPumpCommands(

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/NotificationItem.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/NotificationItem.kt
@@ -38,10 +38,9 @@ import com.jwoglom.pumpx2.pump.messages.response.currentStatus.AlertStatusRespon
 import com.jwoglom.pumpx2.pump.messages.response.currentStatus.CGMAlertStatusResponse
 import com.jwoglom.pumpx2.pump.messages.response.currentStatus.MalfunctionStatusResponse
 import com.jwoglom.pumpx2.pump.messages.response.currentStatus.ReminderStatusResponse
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.delay
 
 val requiredProgress = 0.5f
 
@@ -107,10 +106,8 @@ fun NotificationItem(
                 }
             }
 
-            withContext(Dispatchers.IO) {
-                Thread.sleep(500)
-                refresh()
-            }
+            delay(500)
+            refresh()
         }
     }
 

--- a/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/BolusScreen.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/BolusScreen.kt
@@ -91,9 +91,8 @@ import com.jwoglom.controlx2.shared.util.snakeCaseToSpace
 import com.jwoglom.controlx2.shared.util.twoDecimalPlaces
 import com.jwoglom.controlx2.shared.util.twoDecimalPlaces1000Unit
 import com.jwoglom.pumpx2.pump.messages.bluetooth.PumpStateSupplier
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.delay
 import timber.log.Timber
 
 @OptIn(ExperimentalMaterialApi::class)
@@ -217,16 +216,12 @@ fun BolusScreen(
                 sinceLastFetchTime = 0
             }
 
-            withContext(Dispatchers.IO) {
-                Thread.sleep(250)
-            }
+            delay(250)
             sinceLastFetchTime += 250
         }
         Timber.i("BolusScreen base loading done: ${baseFields.map { it.value }}")
         if (sinceLastFetchTime == 0) {
-            withContext(Dispatchers.IO) {
-                Thread.sleep(250)
-            }
+            delay(250)
         }
         refreshing = false
     }
@@ -737,9 +732,7 @@ fun BolusScreen(
             LaunchedEffect (lastBolusStatusResponse.value) {
                 if (matchesBolusId() == false) {
                     refreshScope.launch {
-                        withContext(Dispatchers.IO) {
-                            Thread.sleep(250)
-                        }
+                        delay(250)
                         sendPumpCommands(
                             SendType.STANDARD,
                             listOf(LastBolusStatusV2Request())
@@ -822,9 +815,7 @@ fun BolusScreen(
                         performCancel()
                         time = 0
                     }
-                    withContext(Dispatchers.IO) {
-                        Thread.sleep(100)
-                    }
+                    delay(100)
                     time += 100
                 }
                 showCancellingDialog = false
@@ -963,7 +954,7 @@ fun BolusScreen(
                     sendPumpCommands(SendType.BUST_CACHE, listOf(CurrentBolusStatusRequest()))
                     refreshScope.launch {
                         repeat(5) {
-                            Thread.sleep(1000)
+                            delay(1000)
                             sendPumpCommands(
                                 SendType.BUST_CACHE,
                                 listOf(CurrentBolusStatusRequest())
@@ -981,7 +972,7 @@ fun BolusScreen(
                         sendPumpCommands(SendType.BUST_CACHE, listOf(CurrentBolusStatusRequest()))
                         refreshScope.launch {
                             repeat(5) {
-                                Thread.sleep(1000)
+                                delay(1000)
                                 sendPumpCommands(
                                     SendType.BUST_CACHE,
                                     listOf(CurrentBolusStatusRequest())

--- a/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/LandingScreen.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/LandingScreen.kt
@@ -56,10 +56,9 @@ import com.jwoglom.pumpx2.pump.messages.request.currentStatus.CurrentEGVGuiDataR
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.GlobalMaxBolusSettingsRequest
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.HomeScreenMirrorRequest
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.InsulinStatusRequest
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.delay
 import timber.log.Timber
 
 @OptIn(ExperimentalMaterialApi::class, ExperimentalWearMaterialApi::class)
@@ -121,7 +120,7 @@ fun LandingScreen(
                 sinceLastFetchTime = 0
             }
 
-            withContext(Dispatchers.IO) { Thread.sleep(250) }
+            delay(250)
             sinceLastFetchTime += 250
         }
         refreshing = false


### PR DESCRIPTION
### Motivation
- UI-layer coroutine code used blocking `Thread.sleep(...)` (often wrapped in `withContext(Dispatchers.IO)`), which can block threads and prevents cooperative cancellation in Compose flows.
- Replace blocking waits with suspend-friendly `delay(...)` to make refresh/retry loops and click handlers cancellation-cooperative while preserving user-visible timing and ordering.

### Description
- Replaced `Thread.sleep(...)` calls with `delay(...)` across mobile and wear presentation layers and adjusted imports accordingly. 
- Removed unnecessary `withContext(Dispatchers.IO)` wrappers in cases where the block only performed a delay and subsequent UI/command calls. 
- Preserved original wait durations and command ordering (examples: 100ms / 250ms / 500ms / 1000ms waits remain as `delay(...)`).
- Changes touch the Compose/UI layer files (including but not limited to `ServiceDisabledMessage.kt`, `AppSetup.kt`, `Actions.kt`, `BolusWindow.kt`, `CGMActions.kt`, `CartridgeActions.kt`, `Dashboard.kt`, `Debug.kt`, `Notifications.kt`, `ProfileActions.kt`, `Settings.kt`, `TempRateWindow.kt`, `NotificationItem.kt`, and corresponding wear UI files) and similar files discovered by a repository-wide grep (~20 files updated).

### Testing
- Ran repository searches to confirm there are no remaining `Thread.sleep(...)` occurrences in the mobile/wear presentation directories and validated that `withContext(Dispatchers.IO)` delay-wrappers were simplified. 
- Adjusted coroutine imports where necessary so `delay` is available in modified files via `import kotlinx.coroutines.delay` and removed unused imports.
- Attempted to compile `:mobile` and `:wear` Kotlin sources using Gradle, but full compilation could not complete in this environment because the Android SDK location is not present (`/opt/android-sdk`), so a complete build was blocked. 
- The static checks above succeeded (no blocking sleeps remain in the touched Compose/UI coroutine flows), and timing/command ordering was preserved in the refactor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa3a7c62ac832c8210be1bc124e0ba)