### PR TITLE
Fix Landing state initialization to react to parent updates

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/Landing.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/Landing.kt
@@ -120,11 +120,13 @@ fun Landing(
     val notificationBundle = ds.notificationBundle.observeAsState()
 
 
-    var selectedItem by remember { mutableStateOf(sectionState) }
+    // Local state owns user-driven tab changes, but must reset when parent route changes.
+    var selectedItem by remember(sectionState) { mutableStateOf(sectionState) }
     val displayBottomScaffold = rememberBottomSheetScaffoldState(
         bottomSheetState = BottomSheetState(bottomScaffoldDisplayState, density=Density(context))
     )
-    var bottomScaffoldState by remember { mutableStateOf(_bottomScaffoldState) }
+    // Local state owns in-screen sheet toggles, while parent can still force a new initial sheet.
+    var bottomScaffoldState by remember(_bottomScaffoldState) { mutableStateOf(_bottomScaffoldState) }
 
     fun showBottomScaffold(): Boolean {
         return displayBottomScaffold.bottomSheetState.isExpanded ||


### PR DESCRIPTION
### Motivation
- Ensure UI local state that is derived from parent parameters updates correctly after the first composition so parent-driven navigation and sheet overrides are reflected in the `Landing` screen.

### Description
- Replace `remember { mutableStateOf(sectionState) }` with `remember(sectionState) { mutableStateOf(sectionState) }` for `selectedItem` and similarly key `bottomScaffoldState` with `remember(_bottomScaffoldState) { mutableStateOf(_bottomScaffoldState) }`, and add concise comments clarifying parent-vs-local source-of-truth.

### Testing
- Attempted `./gradlew :mobile:compileDebugKotlin --console=plain`, which could not complete in this environment because the Android SDK path in `local.properties` (`/opt/android-sdk`) is not available, so compile validation was not performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa3a83af34832c9f81d73e357d9452)