### PR TITLE
Refactor wear bolus picker routes to observe LiveData

### DIFF
--- a/wear/src/main/java/com/jwoglom/controlx2/presentation/WearApp.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/presentation/WearApp.kt
@@ -494,8 +494,10 @@ fun WearApp(
                 }
 
                 composable(Screen.BolusSelectUnitsScreen.route) {
-                    val currentUnits = LocalDataStore.current.bolusCalculatorBuilder.value?.insulinUnits?.total
-                    val maxBolusAmount = LocalDataStore.current.maxBolusAmount.observeAsState()
+                    val ds = LocalDataStore.current
+                    val bolusCalculatorBuilder = ds.bolusCalculatorBuilder.observeAsState()
+                    val maxBolusAmount = ds.maxBolusAmount.observeAsState()
+                    val currentUnits = bolusCalculatorBuilder.value?.insulinUnits?.total
                     LaunchedEffect(Unit) {
                         sendPumpCommands(SendType.CACHED, listOf(GlobalMaxBolusSettingsRequest()))
                     }
@@ -521,8 +523,10 @@ fun WearApp(
                 }
 
                 composable(Screen.BolusSelectCarbsScreen.route) {
-                    val currentCarbs = LocalDataStore.current.bolusCalculatorBuilder.value?.carbsValueGrams?.orElse(null)
-                    val maxCarbAmount = LocalDataStore.current.maxCarbAmount.observeAsState()
+                    val ds = LocalDataStore.current
+                    val bolusCalculatorBuilder = ds.bolusCalculatorBuilder.observeAsState()
+                    val maxCarbAmount = ds.maxCarbAmount.observeAsState()
+                    val currentCarbs = bolusCalculatorBuilder.value?.carbsValueGrams?.orElse(null)
                     SingleNumberPicker(
                         label = "Carbs",
                         maxNumber = when {
@@ -544,8 +548,11 @@ fun WearApp(
                 }
 
                 composable(Screen.BolusSelectBGScreen.route) {
-                    val currentBG = LocalDataStore.current.bolusCalculatorBuilder.value?.glucoseMgdl?.orElse(null)
-                    val glucoseUnit = LocalDataStore.current.glucoseUnitPreference.value ?: GlucoseUnit.MGDL
+                    val ds = LocalDataStore.current
+                    val bolusCalculatorBuilder = ds.bolusCalculatorBuilder.observeAsState()
+                    val glucoseUnitPreference = ds.glucoseUnitPreference.observeAsState()
+                    val currentBG = bolusCalculatorBuilder.value?.glucoseMgdl?.orElse(null)
+                    val glucoseUnit = glucoseUnitPreference.value ?: GlucoseUnit.MGDL
 
                     SingleNumberPicker(
                         label = "BG (${glucoseUnit.abbreviation})",


### PR DESCRIPTION
### Motivation
- Bolus picker routes in `WearApp.kt` mixed direct `LocalDataStore.current.<field>.value` reads with observed state, causing non-reactive UI and inconsistent recomposition.

### Description
- Introduced `val ds = LocalDataStore.current` in the `BolusSelectUnitsScreen`, `BolusSelectCarbsScreen`, and `BolusSelectBGScreen` composable routes.
- Replaced direct `.value` reads for the bolus calculator and glucose unit fields with `observeAsState(...)` to make picker defaults reactive while preserving existing fallback defaults and behavior.
- Kept naming consistent (`ds`) and left non-reactive reads only where intentionally unchanged.

### Testing
- Ran `./gradlew :wear:compileDebugKotlin --console=plain`, which initially failed due to a missing repo-local SDK (`local.properties`).
- Executed `./.codex/setup.sh` to provision the SDK and then ran `./.codex/build.sh`, which completed successfully (`BUILD SUCCESSFUL`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa485963cc832ca9e452c2cbb0df9a)