### PR TITLE
Harden wear CGM text rendering null handling

### DIFF
--- a/wear/src/main/java/com/jwoglom/controlx2/presentation/components/CurrentCGMText.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/presentation/components/CurrentCGMText.kt
@@ -20,6 +20,8 @@ import com.jwoglom.controlx2.presentation.redTheme
 import com.jwoglom.controlx2.shared.enums.GlucoseUnit
 import com.jwoglom.controlx2.shared.util.GlucoseConverter
 
+private fun cgmStatusOrEmpty(cgmStatusText: String?): String = cgmStatusText ?: ""
+
 @Composable
 fun CurrentCGMText(
     cgmSessionState: String?,
@@ -31,9 +33,9 @@ fun CurrentCGMText(
     textStyle: TextStyle? = null,
 ) {
     val displayText = when (cgmSessionState) {
-        "Starting", "Stopped", "Stopping", "Unknown" -> cgmStatusText!!
+        "Starting", "Stopped", "Stopping", "Unknown" -> cgmStatusOrEmpty(cgmStatusText)
         else -> when {
-            !Strings.isNullOrEmpty(cgmStatusText) -> cgmStatusText!!
+            !Strings.isNullOrEmpty(cgmStatusText) -> cgmStatusOrEmpty(cgmStatusText)
             else -> when {
                 cgmReading != null && cgmDeltaArrow != null -> "${GlucoseConverter.format(cgmReading, glucoseUnit)} ${cgmDeltaArrow}"
                 cgmReading != null -> GlucoseConverter.format(cgmReading, glucoseUnit)


### PR DESCRIPTION
### Motivation
- Avoid crashes from force-unwrapping asynchronously-updated CGM status text in the wear composable by providing safe fallbacks when LiveData may be null. 

### Description
- Replaced occurrences of `!!` in `CurrentCGMText` with a small helper `cgmStatusOrEmpty(cgmStatusText)` and used it where status text was previously force-unwrapped, preserving existing display rules and behavior for valid data.

### Testing
- Ran environment setup with `./.codex/setup.sh` and completed a Wear module build with `./.codex/build.sh`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa48626a3c832ca9a93a7c5a2c0b4b)