### PR TITLE
Fix crash when Play Services unavailable

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/MainActivity.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/MainActivity.kt
@@ -173,15 +173,15 @@ class MainActivity : ComponentActivity() {
             dataStore.glucoseUnitPreference.value = GlucoseUnit.MGDL
         }
 
-        // Initialize MessageBus and register as listener
-        if (checkPlayServicesAndInitialize()) {
-            messageBus = MessageBusFactory.createMessageBus(this)
-            messageBus.addMessageListener(object : MessageListener {
-                override fun onMessageReceived(path: String, data: ByteArray, sourceNodeId: String) {
-                    handleMessageReceived(path, data, sourceNodeId)
-                }
-            })
-        }
+        // Always initialize MessageBus (factory handles Play Services fallback internally)
+        messageBus = MessageBusFactory.createMessageBus(this)
+        messageBus.addMessageListener(object : MessageListener {
+            override fun onMessageReceived(path: String, data: ByteArray, sourceNodeId: String) {
+                handleMessageReceived(path, data, sourceNodeId)
+            }
+        })
+        // Show warning dialog if Play Services missing (non-blocking)
+        checkPlayServicesAndInitialize()
         checkNotificationPermissions()
 
 


### PR DESCRIPTION
## Summary
- Always initialize `messageBus` in `onCreate()` regardless of Play Services availability
- `MessageBusFactory` already handles the fallback to `BroadcastMessageBus` when Play Services is missing — the `if (checkPlayServicesAndInitialize())` gate was preventing this fallback from being used
- Fixes `UninitializedPropertyAccessException: lateinit property messageBus has not been initialized` crash in `onResume()` → `sendMessage()` on devices where Play Store is blocked or missing

## Details
The crash occurs because:
1. `checkPlayServicesAndInitialize()` returns `false` when Play Store is unavailable
2. `messageBus` is never created
3. `onResume()` calls `sendMessage()` which accesses the uninitialized `messageBus`

Note: `onDestroy()` already guards against this with `::messageBus.isInitialized`, but `sendMessage()` had no such guard.

## Test plan
- [x] Tested on device without Play Store access — app launches and runs without crash
- [x] `BroadcastMessageBus` is correctly selected as fallback (confirmed via logcat)
- [ ] Verify no regression on devices with Play Services (Wear OS path should be unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)