### PR TITLE
Refactor wear presentation components to use consistent DataStore aliases

### DIFF
--- a/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/components/LandingBasalRow.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/components/LandingBasalRow.kt
@@ -18,10 +18,10 @@ data class BasalRowModel(
 @OptIn(ExperimentalWearMaterialApi::class)
 @Composable
 fun LandingBasalRow() {
-    val store = LocalDataStore.current
+    val ds = LocalDataStore.current
     val model = BasalRowModel(
-        basalRate = store.basalRate.observeAsState().value,
-        basalStatus = store.basalStatus.observeAsState().value,
+        basalRate = ds.basalRate.observeAsState().value,
+        basalStatus = ds.basalStatus.observeAsState().value,
     )
     val text = when (model.basalStatus) {
         BasalStatus.ON,

--- a/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/components/LandingBolusChip.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/components/LandingBolusChip.kt
@@ -12,7 +12,8 @@ import com.jwoglom.controlx2.LocalDataStore
 
 @Composable
 fun LandingBolusChip(onClick: () -> Unit) {
-    val lastBolusStatus = LocalDataStore.current.lastBolusStatus.observeAsState().value
+    val ds = LocalDataStore.current
+    val lastBolusStatus = ds.lastBolusStatus.observeAsState().value
     Chip(
         onClick = onClick,
         label = { Text("Bolus", maxLines = 1, overflow = TextOverflow.Ellipsis) },

--- a/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/components/LandingCgmBatteryRow.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/components/LandingCgmBatteryRow.kt
@@ -10,7 +10,8 @@ import com.jwoglom.controlx2.presentation.components.LineInfoChip
 @OptIn(ExperimentalWearMaterialApi::class)
 @Composable
 fun LandingCgmBatteryRow() {
-    val status = LocalDataStore.current.cgmTransmitterStatus.observeAsState().value
+    val ds = LocalDataStore.current
+    val status = ds.cgmTransmitterStatus.observeAsState().value
     LineInfoChip("CGM Battery", status?.toString() ?: "?")
 }
 

--- a/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/components/LandingCgmSensorRow.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/components/LandingCgmSensorRow.kt
@@ -23,11 +23,11 @@ data class CgmSensorRowModel(
 @Composable
 fun LandingCgmSensorRow() {
     var showExact by remember { mutableStateOf(false) }
-    val store = LocalDataStore.current
+    val ds = LocalDataStore.current
     val model = CgmSensorRowModel(
-        sessionState = store.cgmSessionState.observeAsState().value,
-        expireRelative = store.cgmSessionExpireRelative.observeAsState().value,
-        expireExact = store.cgmSessionExpireExact.observeAsState().value,
+        sessionState = ds.cgmSessionState.observeAsState().value,
+        expireRelative = ds.cgmSessionExpireRelative.observeAsState().value,
+        expireExact = ds.cgmSessionExpireExact.observeAsState().value,
     )
 
     val text = when (model.sessionState) {

--- a/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/components/LandingControlIQRow.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/components/LandingControlIQRow.kt
@@ -11,9 +11,9 @@ import com.jwoglom.controlx2.shared.enums.UserMode
 @OptIn(ExperimentalWearMaterialApi::class)
 @Composable
 fun LandingControlIQRow() {
-    val store = LocalDataStore.current
-    val status = store.controlIQStatus.observeAsState().value
-    val mode = store.controlIQMode.observeAsState().value
+    val ds = LocalDataStore.current
+    val status = ds.controlIQStatus.observeAsState().value
+    val mode = ds.controlIQMode.observeAsState().value
     val text = when (mode) {
         UserMode.SLEEP, UserMode.EXERCISE -> "$mode"
         else -> status?.toString() ?: "?"

--- a/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/components/LandingModeActionsRow.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/components/LandingModeActionsRow.kt
@@ -24,7 +24,8 @@ import androidx.compose.material.icons.filled.KingBed
 
 @Composable
 fun LandingModeActionsRow(onExerciseClick: () -> Unit, onSleepClick: () -> Unit) {
-    val controlIQMode = LocalDataStore.current.controlIQMode.observeAsState().value
+    val ds = LocalDataStore.current
+    val controlIQMode = ds.controlIQMode.observeAsState().value
     LazyRow {
         item {
             Chip(

--- a/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/components/LandingTopRow.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/components/LandingTopRow.kt
@@ -21,12 +21,12 @@ data class LandingTopRowModel(
 
 @Composable
 fun LandingTopRow() {
-    val store = LocalDataStore.current
+    val ds = LocalDataStore.current
     val model = LandingTopRowModel(
-        batteryPercent = store.batteryPercent.observeAsState().value,
-        iobUnits = store.iobUnits.observeAsState().value,
-        cartridgeRemainingUnits = store.cartridgeRemainingUnits.observeAsState().value,
-        cartridgeRemainingEstimate = store.cartridgeRemainingEstimate.observeAsState().value,
+        batteryPercent = ds.batteryPercent.observeAsState().value,
+        iobUnits = ds.iobUnits.observeAsState().value,
+        cartridgeRemainingUnits = ds.cartridgeRemainingUnits.observeAsState().value,
+        cartridgeRemainingEstimate = ds.cartridgeRemainingEstimate.observeAsState().value,
     )
 
     FlowRow {


### PR DESCRIPTION
### Motivation
- Improve readability and consistency across Wear UI components by avoiding repeated inline `LocalDataStore.current.<field>.observeAsState().value` chains and normalizing the local alias name.
- Reduce accidental divergence in observation patterns to make future maintenance and audits of observed state simpler.

### Description
- Introduced a local alias `val ds = LocalDataStore.current` in touched composables and replaced inline observation chains with `ds.<field>.observeAsState().value` observed locals to preserve behavior while simplifying expressions.
- Normalized previous `store` alias usages to `ds` for consistency in all modified files.
- Files updated: `LandingBasalRow.kt`, `LandingBolusChip.kt`, `LandingCgmBatteryRow.kt`, `LandingCgmSensorRow.kt`, `LandingControlIQRow.kt`, `LandingModeActionsRow.kt`, and `LandingTopRow.kt`.

### Testing
- Verified no remaining inline patterns by running `rg "LocalDataStore\.current\.[A-Za-z0-9_]+\.observeAsState\(\)\.value" wear/src/main/java/com/jwoglom/controlx2/presentation/ui/components` which returned no matches.
- Confirmed consistent aliasing with `rg "LocalDataStore\.current" <touched files>` showing `val ds = LocalDataStore.current` in modified files.
- Performed an automated Wear module compilation via the repo helper `./.codex/build.sh` which ran the `:wear:compileDebugKotlin` task successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa486c369c832c98ba196b77c3e661)