### PR TITLE
Nightscout: normalize URLs, hash API secret, add connection checks and sync status/UI

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/NightscoutSettings.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/NightscoutSettings.kt
@@ -42,10 +42,15 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.jwoglom.controlx2.sync.nightscout.NightscoutSyncConfig
+import com.jwoglom.controlx2.sync.nightscout.NightscoutSyncStatusStore
 import com.jwoglom.controlx2.sync.nightscout.ProcessorType
 import com.jwoglom.controlx2.sync.nightscout.NightscoutSyncWorker
+import com.jwoglom.controlx2.sync.nightscout.normalizeNightscoutUrl
 import com.jwoglom.controlx2.presentation.components.HeaderLine
 import kotlinx.coroutines.launch
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 @Composable
 fun NightscoutSettings(
@@ -58,6 +63,7 @@ fun NightscoutSettings(
     val coroutineScope = rememberCoroutineScope()
 
     var config by remember { mutableStateOf(NightscoutSyncConfig.load(prefs)) }
+    var syncStatus by remember { mutableStateOf(NightscoutSyncStatusStore.load(prefs)) }
     var showUrlDialog by remember { mutableStateOf(false) }
     var showApiSecretDialog by remember { mutableStateOf(false) }
     var showProcessorsDialog by remember { mutableStateOf(false) }
@@ -109,6 +115,51 @@ fun NightscoutSettings(
                         } else {
                             NightscoutSyncWorker.stopIfRunning()
                             Toast.makeText(context, "Nightscout sync disabled", Toast.LENGTH_SHORT).show()
+                        }
+
+                        syncStatus = NightscoutSyncStatusStore.load(prefs)
+                    }
+                )
+                Divider()
+            }
+
+            item {
+                ListItem(
+                    headlineContent = { Text("Last successful sync") },
+                    supportingContent = {
+                        Text(
+                            syncStatus.lastSuccessfulSyncMillis?.let { formatTimestamp(it) } ?: "Never"
+                        )
+                    }
+                )
+                Divider()
+            }
+
+            item {
+                val connectionMessage = if (!config.enabled) {
+                    "Nightscout sync is disabled"
+                } else if (!config.isValid()) {
+                    "Nightscout config is incomplete"
+                } else if (!syncStatus.lastError.isNullOrBlank()) {
+                    syncStatus.lastError ?: "Connection error"
+                } else {
+                    "Connected"
+                }
+
+                val supportingMessage = if (config.enabled && !syncStatus.lastError.isNullOrBlank()) {
+                    syncStatus.lastErrorMillis?.let { "Last failure: ${formatTimestamp(it)}" } ?: ""
+                } else {
+                    ""
+                }
+
+                ListItem(
+                    headlineContent = { Text("Connection status") },
+                    supportingContent = {
+                        Column {
+                            Text(connectionMessage)
+                            if (supportingMessage.isNotBlank()) {
+                                Text(supportingMessage)
+                            }
                         }
                     }
                 )
@@ -193,6 +244,7 @@ fun NightscoutSettings(
                         if (config.enabled && config.isValid()) {
                             coroutineScope.launch {
                                 NightscoutSyncWorker.getInstance(context, prefs, pumpSid).syncNow()
+                                syncStatus = NightscoutSyncStatusStore.load(prefs)
                                 Toast.makeText(context, "Sync triggered", Toast.LENGTH_SHORT).show()
                             }
                         } else {
@@ -212,21 +264,41 @@ fun NightscoutSettings(
     // URL Dialog
     if (showUrlDialog) {
         var urlInput by remember { mutableStateOf(config.nightscoutUrl) }
+        var urlError by remember { mutableStateOf<String?>(null) }
         AlertDialog(
             onDismissRequest = { showUrlDialog = false },
             title = { Text("Nightscout URL") },
             text = {
-                OutlinedTextField(
-                    value = urlInput,
-                    onValueChange = { urlInput = it },
-                    label = { Text("URL") },
-                    placeholder = { Text("https://your-nightscout.herokuapp.com") },
-                    modifier = Modifier.fillMaxWidth()
-                )
+                Column {
+                    OutlinedTextField(
+                        value = urlInput,
+                        onValueChange = {
+                            urlInput = it
+                            urlError = null
+                        },
+                        label = { Text("URL") },
+                        placeholder = { Text("https://your-nightscout.herokuapp.com") },
+                        isError = urlError != null,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+
+                    if (urlError != null) {
+                        Text(
+                            text = urlError!!,
+                            modifier = Modifier.padding(top = 8.dp)
+                        )
+                    }
+                }
             },
             confirmButton = {
                 TextButton(onClick = {
-                    val newConfig = config.copy(nightscoutUrl = urlInput.trim())
+                    val normalizedUrl = normalizeNightscoutUrl(urlInput)
+                    if (normalizedUrl == null) {
+                        urlError = "Please enter a valid Nightscout URL"
+                        return@TextButton
+                    }
+
+                    val newConfig = config.copy(nightscoutUrl = normalizedUrl)
                     config = newConfig
                     NightscoutSyncConfig.save(prefs, newConfig)
                     showUrlDialog = false
@@ -404,4 +476,11 @@ fun NightscoutSettings(
             }
         )
     }
+}
+
+private fun formatTimestamp(timestampMillis: Long): String {
+    val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+    return Instant.ofEpochMilli(timestampMillis)
+        .atZone(ZoneId.systemDefault())
+        .format(formatter)
 }

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/NightscoutAuth.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/NightscoutAuth.kt
@@ -1,0 +1,11 @@
+package com.jwoglom.controlx2.sync.nightscout
+
+import java.security.MessageDigest
+
+const val NightscoutApiSecretHeader = "api-secret"
+
+fun hashNightscoutApiSecret(apiSecret: String): String {
+    return MessageDigest.getInstance("SHA-1")
+        .digest(apiSecret.toByteArray(Charsets.UTF_8))
+        .joinToString("") { "%02x".format(it) }
+}

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/NightscoutSyncConfig.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/NightscoutSyncConfig.kt
@@ -75,13 +75,13 @@ data class NightscoutSyncConfig(
      * Validate configuration
      */
     fun isValid(): Boolean {
-        return nightscoutUrl.isNotBlank() && apiSecret.isNotBlank()
+        return normalizeNightscoutUrl(nightscoutUrl) != null && apiSecret.isNotBlank()
     }
 
     /**
      * Get sanitized Nightscout URL (remove trailing slash)
      */
     fun getSanitizedUrl(): String {
-        return nightscoutUrl.trimEnd('/')
+        return normalizeNightscoutUrl(nightscoutUrl) ?: nightscoutUrl.trimEnd('/')
     }
 }

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/NightscoutSyncStatusStore.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/NightscoutSyncStatusStore.kt
@@ -1,0 +1,42 @@
+package com.jwoglom.controlx2.sync.nightscout
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+
+data class NightscoutSyncStatus(
+    val lastSuccessfulSyncMillis: Long? = null,
+    val lastError: String? = null,
+    val lastErrorMillis: Long? = null
+)
+
+object NightscoutSyncStatusStore {
+    private const val PREF_LAST_SUCCESS = "nightscout_last_successful_sync"
+    private const val PREF_LAST_ERROR = "nightscout_last_error"
+    private const val PREF_LAST_ERROR_TIME = "nightscout_last_error_time"
+
+    fun load(prefs: SharedPreferences): NightscoutSyncStatus {
+        val success = prefs.getLong(PREF_LAST_SUCCESS, -1L).takeIf { it > 0 }
+        val error = prefs.getString(PREF_LAST_ERROR, null)
+        val errorTime = prefs.getLong(PREF_LAST_ERROR_TIME, -1L).takeIf { it > 0 }
+        return NightscoutSyncStatus(
+            lastSuccessfulSyncMillis = success,
+            lastError = error,
+            lastErrorMillis = errorTime
+        )
+    }
+
+    fun recordSuccess(prefs: SharedPreferences, timestampMillis: Long = System.currentTimeMillis()) {
+        prefs.edit {
+            putLong(PREF_LAST_SUCCESS, timestampMillis)
+            remove(PREF_LAST_ERROR)
+            remove(PREF_LAST_ERROR_TIME)
+        }
+    }
+
+    fun recordFailure(prefs: SharedPreferences, error: String, timestampMillis: Long = System.currentTimeMillis()) {
+        prefs.edit {
+            putString(PREF_LAST_ERROR, error)
+            putLong(PREF_LAST_ERROR_TIME, timestampMillis)
+        }
+    }
+}

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/NightscoutSyncWorker.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/NightscoutSyncWorker.kt
@@ -13,6 +13,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URL
 
 /**
  * Worker for periodic Nightscout sync
@@ -107,6 +111,22 @@ class NightscoutSyncWorker(
 
             if (!config.isValid()) {
                 Timber.e("Nightscout configuration is invalid, skipping sync")
+                NightscoutSyncStatusStore.recordFailure(prefs, "Nightscout configuration is invalid")
+                return
+            }
+
+            val normalizedUrl = normalizeNightscoutUrl(config.nightscoutUrl)
+            if (normalizedUrl == null) {
+                Timber.e("Nightscout URL is invalid, skipping sync")
+                NightscoutSyncStatusStore.recordFailure(prefs, "Nightscout URL is invalid")
+                return
+            }
+
+            val connectivityCheck = checkNightscoutConnection(normalizedUrl, config.apiSecret)
+            if (connectivityCheck.isFailure) {
+                val message = connectivityCheck.exceptionOrNull()?.message ?: "Connection test failed"
+                Timber.e("Nightscout connection check failed: $message")
+                NightscoutSyncStatusStore.recordFailure(prefs, "Connection failed: $message")
                 return
             }
 
@@ -115,7 +135,7 @@ class NightscoutSyncWorker(
                 HistoryLogDatabase.getDatabase(context).historyLogDao()
             )
             val nightscoutClient = NightscoutClient(
-                config.getSanitizedUrl(),
+                normalizedUrl,
                 config.apiSecret
             )
             val syncStateDao = NightscoutSyncStateDatabase.getDatabase(context)
@@ -132,6 +152,7 @@ class NightscoutSyncWorker(
             // Perform sync
             when (val result = coordinator.syncAll()) {
                 is SyncResult.Success -> {
+                    NightscoutSyncStatusStore.recordSuccess(prefs)
                     Timber.i(
                         "Nightscout sync completed: " +
                         "processed ${result.processedCount}, " +
@@ -140,17 +161,48 @@ class NightscoutSyncWorker(
                     )
                 }
                 is SyncResult.NoData -> {
+                    NightscoutSyncStatusStore.recordSuccess(prefs)
                     Timber.d("No new data to sync")
                 }
                 is SyncResult.Disabled -> {
                     Timber.d("Nightscout sync is disabled")
                 }
                 is SyncResult.InvalidConfig -> {
+                    NightscoutSyncStatusStore.recordFailure(prefs, "Nightscout configuration is invalid")
                     Timber.e("Nightscout configuration is invalid")
                 }
             }
         } catch (e: Exception) {
+            NightscoutSyncStatusStore.recordFailure(
+                prefs,
+                e.message ?: "Unexpected Nightscout sync error"
+            )
             Timber.e(e, "Error during Nightscout sync")
+        }
+    }
+
+    private fun checkNightscoutConnection(baseUrl: String, apiSecret: String): Result<Unit> {
+        return runCatching {
+            val statusUrl = URL("$baseUrl/api/v1/verifyauth")
+            val connection = (statusUrl.openConnection() as HttpURLConnection).apply {
+                requestMethod = "GET"
+                setRequestProperty(NightscoutApiSecretHeader, hashNightscoutApiSecret(apiSecret))
+                connectTimeout = 10000
+                readTimeout = 10000
+                doInput = true
+            }
+
+            try {
+                val responseCode = connection.responseCode
+                if (responseCode !in 200..299) {
+                    val errorBody = connection.errorStream?.use { stream ->
+                        BufferedReader(InputStreamReader(stream)).readText()
+                    } ?: ""
+                    throw IllegalStateException("HTTP $responseCode $errorBody".trim())
+                }
+            } finally {
+                connection.disconnect()
+            }
         }
     }
 

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/NightscoutUrlFormatter.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/NightscoutUrlFormatter.kt
@@ -1,0 +1,27 @@
+package com.jwoglom.controlx2.sync.nightscout
+
+import java.net.URI
+
+fun normalizeNightscoutUrl(rawUrl: String): String? {
+    val trimmed = rawUrl.trim()
+    if (trimmed.isBlank()) {
+        return ""
+    }
+
+    val withScheme = if (trimmed.contains("://")) {
+        trimmed
+    } else {
+        "https://$trimmed"
+    }
+
+    return try {
+        val uri = URI(withScheme)
+        if (uri.scheme.isNullOrBlank() || uri.host.isNullOrBlank()) {
+            null
+        } else {
+            uri.toString().trimEnd('/')
+        }
+    } catch (_: Exception) {
+        null
+    }
+}

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/api/NightscoutClient.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/api/NightscoutClient.kt
@@ -2,6 +2,8 @@ package com.jwoglom.controlx2.sync.nightscout.api
 
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import com.jwoglom.controlx2.sync.nightscout.NightscoutApiSecretHeader
+import com.jwoglom.controlx2.sync.nightscout.hashNightscoutApiSecret
 import com.jwoglom.controlx2.sync.nightscout.models.NightscoutDeviceStatus
 import com.jwoglom.controlx2.sync.nightscout.models.NightscoutEntry
 import com.jwoglom.controlx2.sync.nightscout.models.NightscoutTreatment
@@ -13,7 +15,6 @@ import java.io.InputStreamReader
 import java.io.OutputStreamWriter
 import java.net.HttpURLConnection
 import java.net.URL
-import java.security.MessageDigest
 
 /**
  * Nightscout API client implementation
@@ -27,11 +28,7 @@ class NightscoutClient(
 ) : NightscoutApi {
 
     private val gson = Gson()
-    private val apiSecretHash: String by lazy {
-        MessageDigest.getInstance("SHA-1")
-            .digest(apiSecret.toByteArray())
-            .joinToString("") { "%02x".format(it) }
-    }
+    private val apiSecretHash: String by lazy { hashNightscoutApiSecret(apiSecret) }
 
     override suspend fun uploadEntries(entries: List<NightscoutEntry>): Result<Int> {
         return withContext(Dispatchers.IO) {
@@ -107,7 +104,7 @@ class NightscoutClient(
         return try {
             connection.requestMethod = "POST"
             connection.setRequestProperty("Content-Type", "application/json")
-            connection.setRequestProperty("api-secret", apiSecretHash)
+            connection.setRequestProperty(NightscoutApiSecretHeader, apiSecretHash)
             connection.doOutput = true
             connection.connectTimeout = 30000
             connection.readTimeout = 30000
@@ -142,7 +139,7 @@ class NightscoutClient(
 
         return try {
             connection.requestMethod = "GET"
-            connection.setRequestProperty("api-secret", apiSecretHash)
+            connection.setRequestProperty(NightscoutApiSecretHeader, apiSecretHash)
             connection.connectTimeout = 30000
             connection.readTimeout = 30000
 

--- a/mobile/src/test/java/com/jwoglom/controlx2/sync/nightscout/NightscoutClientTest.kt
+++ b/mobile/src/test/java/com/jwoglom/controlx2/sync/nightscout/NightscoutClientTest.kt
@@ -1,9 +1,7 @@
 package com.jwoglom.controlx2.sync.nightscout
 
-import com.jwoglom.controlx2.sync.nightscout.api.NightscoutClient
 import org.junit.Assert.*
 import org.junit.Test
-import java.security.MessageDigest
 
 /**
  * Unit tests for NightscoutClient
@@ -14,13 +12,12 @@ class NightscoutClientTest {
     fun testApiSecretHashing() {
         // Test SHA-1 hash calculation
         val apiSecret = "test-secret-123"
-        val expectedHash = MessageDigest.getInstance("SHA-1")
-            .digest(apiSecret.toByteArray())
-            .joinToString("") { "%02x".format(it) }
+        val expectedHash = hashNightscoutApiSecret(apiSecret)
 
         // The client should use this hash for authentication
         assertNotNull(expectedHash)
         assertEquals(40, expectedHash.length) // SHA-1 produces 40 hex characters
+        assertEquals("api-secret", NightscoutApiSecretHeader)
     }
 
     @Test
@@ -51,13 +48,9 @@ class NightscoutClientTest {
     @Test
     fun testHashConsistency() {
         val secret = "my-secret"
-        val hash1 = MessageDigest.getInstance("SHA-1")
-            .digest(secret.toByteArray())
-            .joinToString("") { "%02x".format(it) }
+        val hash1 = hashNightscoutApiSecret(secret)
 
-        val hash2 = MessageDigest.getInstance("SHA-1")
-            .digest(secret.toByteArray())
-            .joinToString("") { "%02x".format(it) }
+        val hash2 = hashNightscoutApiSecret(secret)
 
         // Same secret should produce same hash
         assertEquals(hash1, hash2)
@@ -68,13 +61,9 @@ class NightscoutClientTest {
         val secret1 = "secret1"
         val secret2 = "secret2"
 
-        val hash1 = MessageDigest.getInstance("SHA-1")
-            .digest(secret1.toByteArray())
-            .joinToString("") { "%02x".format(it) }
+        val hash1 = hashNightscoutApiSecret(secret1)
 
-        val hash2 = MessageDigest.getInstance("SHA-1")
-            .digest(secret2.toByteArray())
-            .joinToString("") { "%02x".format(it) }
+        val hash2 = hashNightscoutApiSecret(secret2)
 
         // Different secrets should produce different hashes
         assertNotEquals(hash1, hash2)
@@ -83,9 +72,7 @@ class NightscoutClientTest {
     @Test
     fun testEmptySecret() {
         val secret = ""
-        val hash = MessageDigest.getInstance("SHA-1")
-            .digest(secret.toByteArray())
-            .joinToString("") { "%02x".format(it) }
+        val hash = hashNightscoutApiSecret(secret)
 
         // Empty string should still produce a valid hash
         assertEquals(40, hash.length)

--- a/mobile/src/test/java/com/jwoglom/controlx2/sync/nightscout/NightscoutUrlFormatterTest.kt
+++ b/mobile/src/test/java/com/jwoglom/controlx2/sync/nightscout/NightscoutUrlFormatterTest.kt
@@ -1,0 +1,25 @@
+package com.jwoglom.controlx2.sync.nightscout
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class NightscoutUrlFormatterTest {
+    @Test
+    fun normalizeNightscoutUrl_addsHttpsWhenMissingScheme() {
+        val normalized = normalizeNightscoutUrl("example.com")
+        assertEquals("https://example.com", normalized)
+    }
+
+    @Test
+    fun normalizeNightscoutUrl_removesTrailingSlash() {
+        val normalized = normalizeNightscoutUrl("https://example.com/")
+        assertEquals("https://example.com", normalized)
+    }
+
+    @Test
+    fun normalizeNightscoutUrl_returnsNullForInvalidUrl() {
+        val normalized = normalizeNightscoutUrl("http://")
+        assertNull(normalized)
+    }
+}


### PR DESCRIPTION
### Motivation

- Improve robustness of Nightscout sync by validating and normalizing configured URLs and surfacing connection status to the user.
- Centralize API secret hashing and consistently use the hashed header for Nightscout requests.
- Track last successful sync and last error times so users can diagnose connectivity issues.

### Description

- Added `normalizeNightscoutUrl` in `NightscoutUrlFormatter.kt` to sanitize and validate Nightscout base URLs and updated `NightscoutSyncConfig.isValid` and `getSanitizedUrl` to use it.
- Introduced `hashNightscoutApiSecret` and `NightscoutApiSecretHeader` in `NightscoutAuth.kt` and switched `NightscoutClient` to use the header constant and hashed secret.
- Implemented `NightscoutSyncStatusStore` to persist `lastSuccessfulSyncMillis`, `lastError`, and `lastErrorMillis`, and updated `NightscoutSyncWorker` to perform a connectivity check (`/api/v1/verifyauth`), record success/failure, and use the normalized base URL for the API client.
- Enhanced the settings UI in `NightscoutSettings.kt` to display last successful sync, connection status and error timestamps, validate the Nightscout URL in the dialog, and added `formatTimestamp` for human-readable times.

### Testing

- Ran unit tests `NightscoutClientTest` and `NightscoutUrlFormatterTest`, and they completed successfully.
- Verified that new URL normalization and API secret hashing unit assertions pass in the test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b098c5497c832cabdb77b9e537f229)