### PR TITLE
Persist dashboard CGM chart time range selection (fix #94)

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/Prefs.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/Prefs.kt
@@ -198,6 +198,17 @@ class Prefs(val context: Context) {
         prefs().edit().putString("http-debug-api-password", s).commit()
     }
 
+    /**
+     * Time range selected for the dashboard CGM/basal chart.
+     */
+    fun dashboardChartTimeRange(): String? {
+        return prefs().getString("dashboard-chart-time-range", null)
+    }
+
+    fun setDashboardChartTimeRange(timeRange: String) {
+        prefs().edit().putString("dashboard-chart-time-range", timeRange).commit()
+    }
+
     fun prefs(): SharedPreferences {
         return context.getSharedPreferences("WearX2", WearableListenerService.MODE_PRIVATE)
     }

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/VicoCgmChart.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/VicoCgmChart.kt
@@ -46,12 +46,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color as ComposeColor
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.jwoglom.controlx2.LocalDataStore
+import com.jwoglom.controlx2.Prefs
 import com.jwoglom.controlx2.db.historylog.HistoryLogItem
 import com.jwoglom.controlx2.db.historylog.HistoryLogViewModel
 import com.jwoglom.controlx2.presentation.theme.CardBackground
@@ -389,6 +391,10 @@ enum class TimeRange(val label: String, val hours: Int) {
     SIX_HOURS("6h", 6),
     TWELVE_HOURS("12h", 12),
     TWENTY_FOUR_HOURS("24h", 24)
+}
+
+private fun String.toTimeRangeOrNull(): TimeRange? {
+    return TimeRange.values().firstOrNull { it.name == this }
 }
 
 // Helper function to fetch and convert CGM data
@@ -2101,7 +2107,13 @@ fun VicoCgmChartCard(
     modifier: Modifier = Modifier,
     previewData: ChartPreviewData? = null
 ) {
-    var selectedTimeRange by remember { mutableStateOf(TimeRange.SIX_HOURS) }
+    val context = LocalContext.current
+    val prefs = remember(context) { Prefs(context) }
+    var selectedTimeRange by remember {
+        mutableStateOf(
+            prefs.dashboardChartTimeRange()?.toTimeRangeOrNull() ?: TimeRange.SIX_HOURS
+        )
+    }
 
     Card(
         modifier = modifier
@@ -2129,7 +2141,10 @@ fun VicoCgmChartCard(
             ) {
                 ChartTimeRangeSelector(
                     selectedRange = selectedTimeRange,
-                    onRangeSelected = { selectedTimeRange = it }
+                    onRangeSelected = {
+                        selectedTimeRange = it
+                        prefs.setDashboardChartTimeRange(it.name)
+                    }
                 )
             }
 


### PR DESCRIPTION
### Motivation

- Remember the user-selected CGM/basal chart time frame so the dashboard restores the same `3h/6h/12h/24h` view on future app loads.

### Description

- Add `Prefs.dashboardChartTimeRange()` and `Prefs.setDashboardChartTimeRange()` to read/write the `dashboard-chart-time-range` preference.
- Initialize `VicoCgmChartCard` selected range from `Prefs` using `LocalContext` and a safe fallback to `TimeRange.SIX_HOURS` when no preference or an invalid value exists.
- Persist changes when the user taps a different range chip by saving `it.name` via `prefs.setDashboardChartTimeRange(it.name)`.
- Add a small helper `String.toTimeRangeOrNull()` to convert stored names back into the `TimeRange` enum.

### Testing

- Ran `./gradlew --version` successfully to validate the Gradle environment.
- Attempted `./gradlew :mobile:compileDebugKotlin --console=plain --no-daemon` in the container but the compile timed out before completion; no other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6499c79d8832c90c8bac57d4a0c9c)