### PR TITLE
Add xDrip broadcast integration: XdripMessageDispatcher and XdripBroadcastSender with tests

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/CommService.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/CommService.kt
@@ -45,6 +45,7 @@ import com.jwoglom.controlx2.shared.util.setupTimber
 import com.jwoglom.controlx2.shared.util.shortTime
 import com.jwoglom.controlx2.shared.util.twoDecimalPlaces
 import com.jwoglom.controlx2.sync.nightscout.NightscoutSyncWorker
+import com.jwoglom.controlx2.sync.xdrip.XdripMessageDispatcher
 import com.jwoglom.controlx2.util.AppVersionCheck
 import com.jwoglom.controlx2.util.DataClientState
 import com.jwoglom.controlx2.util.HistoryLogFetcher
@@ -240,6 +241,7 @@ class CommService : Service() {
 
         private inner class Pump(var tandemConfig: TandemConfig) : TandemPump(applicationContext, tandemConfig) {
             private val scope = CoroutineScope(SupervisorJob(parent = supervisorJob) + Dispatchers.IO)
+            private val xdripMessageDispatcher = XdripMessageDispatcher(this@CommService)
             var lastPeripheral: BluetoothPeripheral? = null
             var isConnected = false
             var pumpSid: Int? = null
@@ -320,8 +322,12 @@ class CommService : Service() {
                         }
                     }
                 }
+
+                message?.let { xdripMessageDispatcher.onReceiveMessage(it) }
                 message?.let { updateNotificationWithPumpData(it) }
             }
+
+
 
             override fun onReceiveQualifyingEvent(
                 peripheral: BluetoothPeripheral?,

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/xdrip/XdripBroadcastSender.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/xdrip/XdripBroadcastSender.kt
@@ -1,0 +1,136 @@
+package com.jwoglom.controlx2.sync.xdrip
+
+import android.content.Context
+import android.content.Intent
+import timber.log.Timber
+
+interface XdripBroadcaster {
+    fun sendSgv(sgvsJsonArrayString: String, minimumIntervalSeconds: Int? = null): Boolean
+    fun sendDeviceStatus(deviceStatusJsonString: String, minimumIntervalSeconds: Int? = null): Boolean
+    fun sendTreatments(
+        treatmentsJsonString: String,
+        minimumIntervalSeconds: Int? = null,
+        alsoSendNewFood: Boolean = true
+    ): Boolean
+
+    fun sendExternalStatusline(statusline: String, minimumIntervalSeconds: Int? = null): Boolean
+}
+
+/**
+ * Sends xDrip-compatible broadcast intents for glucose, treatments, and status updates.
+ */
+class XdripBroadcastSender(
+    private val sendBroadcastFn: (action: String, extraKey: String, payload: String) -> Unit,
+    private val nowMillisFn: () -> Long = { System.currentTimeMillis() }
+) : XdripBroadcaster {
+    constructor(context: Context) : this(
+        sendBroadcastFn = { action, extraKey, payload ->
+            val intent = Intent(action).apply {
+                `package` = "com.eveningoutpost.dexdrip"
+                putExtra(extraKey, payload)
+            }
+            context.sendBroadcast(intent)
+        }
+    )
+
+    companion object {
+        const val ACTION_NEW_SGV = "info.nightscout.client.NEW_SGV"
+        const val ACTION_NEW_DEVICE_STATUS = "info.nightscout.client.NEW_DEVICESTATUS"
+        const val ACTION_NEW_TREATMENT = "info.nightscout.client.NEW_TREATMENT"
+        const val ACTION_NEW_FOOD = "info.nightscout.client.NEW_FOOD"
+        const val ACTION_EXTERNAL_STATUSLINE = "com.eveningoutpost.dexdrip.ExternalStatusline"
+
+        private const val EXTRA_SGVS = "sgvs"
+        private const val EXTRA_DEVICESTATUS = "devicestatus"
+        private const val EXTRA_TREATMENTS = "treatments"
+        private const val EXTRA_EXTERNAL_STATUSLINE = "com.eveningoutpost.dexdrip.Extras.Statusline"
+    }
+
+    private data class LastSentState(
+        var payload: String,
+        var sentAtMillis: Long
+    )
+
+    private val cache: MutableMap<String, LastSentState> = mutableMapOf()
+
+    override fun sendSgv(sgvsJsonArrayString: String, minimumIntervalSeconds: Int?): Boolean {
+        return sendWithCache(
+            cacheKey = "sgv",
+            action = ACTION_NEW_SGV,
+            extraKey = EXTRA_SGVS,
+            payload = sgvsJsonArrayString,
+            minimumIntervalSeconds = minimumIntervalSeconds
+        )
+    }
+
+    override fun sendDeviceStatus(deviceStatusJsonString: String, minimumIntervalSeconds: Int?): Boolean {
+        return sendWithCache(
+            cacheKey = "device_status",
+            action = ACTION_NEW_DEVICE_STATUS,
+            extraKey = EXTRA_DEVICESTATUS,
+            payload = deviceStatusJsonString,
+            minimumIntervalSeconds = minimumIntervalSeconds
+        )
+    }
+
+    override fun sendTreatments(
+        treatmentsJsonString: String,
+        minimumIntervalSeconds: Int?,
+        alsoSendNewFood: Boolean
+    ): Boolean {
+        val sentTreatment = sendWithCache(
+            cacheKey = "treatments",
+            action = ACTION_NEW_TREATMENT,
+            extraKey = EXTRA_TREATMENTS,
+            payload = treatmentsJsonString,
+            minimumIntervalSeconds = minimumIntervalSeconds
+        )
+
+        if (alsoSendNewFood && sentTreatment) {
+            sendBroadcast(ACTION_NEW_FOOD, EXTRA_TREATMENTS, treatmentsJsonString)
+        }
+
+        return sentTreatment
+    }
+
+    override fun sendExternalStatusline(statusline: String, minimumIntervalSeconds: Int?): Boolean {
+        return sendWithCache(
+            cacheKey = "statusline",
+            action = ACTION_EXTERNAL_STATUSLINE,
+            extraKey = EXTRA_EXTERNAL_STATUSLINE,
+            payload = statusline,
+            minimumIntervalSeconds = minimumIntervalSeconds
+        )
+    }
+
+    private fun sendWithCache(
+        cacheKey: String,
+        action: String,
+        extraKey: String,
+        payload: String,
+        minimumIntervalSeconds: Int?
+    ): Boolean {
+        val now = nowMillisFn()
+        val minIntervalMillis = (minimumIntervalSeconds ?: 0).coerceAtLeast(0) * 1000L
+        val previous = cache[cacheKey]
+
+        if (previous != null && previous.payload == payload) {
+            Timber.d("xDrip broadcast suppressed (%s): duplicate payload", cacheKey)
+            return false
+        }
+
+        if (previous != null && minIntervalMillis > 0 && (now - previous.sentAtMillis) < minIntervalMillis) {
+            Timber.d("xDrip broadcast suppressed (%s): under min interval", cacheKey)
+            return false
+        }
+
+        sendBroadcast(action, extraKey, payload)
+        cache[cacheKey] = LastSentState(payload = payload, sentAtMillis = now)
+        return true
+    }
+
+    private fun sendBroadcast(action: String, extraKey: String, payload: String) {
+        sendBroadcastFn(action, extraKey, payload)
+        Timber.i("Sent xDrip broadcast action=%s extra=%s", action, extraKey)
+    }
+}

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/xdrip/XdripMessageDispatcher.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/xdrip/XdripMessageDispatcher.kt
@@ -1,0 +1,195 @@
+package com.jwoglom.controlx2.sync.xdrip
+
+import android.content.Context
+import com.jwoglom.controlx2.Prefs
+import com.jwoglom.controlx2.shared.util.twoDecimalPlaces
+import com.jwoglom.pumpx2.pump.messages.Message
+import com.jwoglom.pumpx2.pump.messages.models.InsulinUnit
+import com.jwoglom.pumpx2.pump.messages.response.control.InitiateBolusResponse
+import com.jwoglom.pumpx2.pump.messages.response.currentStatus.ControlIQIOBResponse
+import com.jwoglom.pumpx2.pump.messages.response.currentStatus.CurrentBasalStatusResponse
+import com.jwoglom.pumpx2.pump.messages.response.currentStatus.CurrentBatteryAbstractResponse
+import com.jwoglom.pumpx2.pump.messages.response.currentStatus.CurrentBolusStatusResponse
+import com.jwoglom.pumpx2.pump.messages.response.currentStatus.CurrentEGVGuiDataResponse
+import com.jwoglom.pumpx2.pump.messages.response.currentStatus.InsulinStatusResponse
+import org.json.JSONArray
+import org.json.JSONObject
+import java.time.Instant
+
+data class TimedPumpValue<T>(
+    var value: T,
+    var receivedAt: Instant
+)
+
+private data class LatestPumpSnapshot(
+    var batteryPercent: TimedPumpValue<Int>? = null,
+    var iobUnits: TimedPumpValue<Double>? = null,
+    var cartridgeUnits: TimedPumpValue<Int>? = null,
+    var basalUnitsPerHour: TimedPumpValue<Double>? = null,
+    var sgvMgdl: TimedPumpValue<Int>? = null,
+)
+
+internal sealed class DispatchEvent {
+    data class PumpBattery(val percent: Int) : DispatchEvent()
+    data class PumpIob(val units: Double) : DispatchEvent()
+    data class PumpReservoir(val units: Int) : DispatchEvent()
+    data class PumpBasal(val unitsPerHour: Double) : DispatchEvent()
+    data class CgmSgv(val mgdl: Int) : DispatchEvent()
+    data class TreatmentInitiated(val bolusId: Int, val status: String) : DispatchEvent()
+    data class TreatmentStatus(val bolusId: Int, val requestedVolumeMilli: Long, val status: String, val timestamp: Instant) : DispatchEvent()
+    data object Other : DispatchEvent()
+}
+
+class XdripMessageDispatcher(
+    private val broadcaster: XdripBroadcaster,
+    private val configProvider: () -> XdripSyncConfig,
+    private val nowProvider: () -> Instant = { Instant.now() }
+) {
+    constructor(context: Context) : this(
+        broadcaster = XdripBroadcastSender(context),
+        configProvider = { XdripSyncConfig.load(Prefs(context).prefs()) }
+    )
+
+    private val latestPumpSnapshot = LatestPumpSnapshot()
+
+    fun onReceiveMessage(message: Message) {
+        onEvent(message.toDispatchEvent())
+    }
+
+    internal fun onEvent(event: DispatchEvent) {
+        val config = configProvider()
+        if (!config.enabled) return
+
+        val receivedAt = nowProvider()
+        val category = updateSnapshot(event, receivedAt)
+
+        if (config.sendCgmSgv && event is DispatchEvent.CgmSgv) {
+            val sgvPayload = JSONArray().put(
+                JSONObject().apply {
+                    put("sgv", event.mgdl)
+                    put("date", receivedAt.toEpochMilli())
+                    put("dateString", receivedAt.toString())
+                }
+            ).toString()
+            broadcaster.sendSgv(sgvPayload, config.cgmSgvMinimumIntervalSeconds)
+        }
+
+        if (config.sendPumpDeviceStatus && category == StatusCategory.PUMP_STATUS) {
+            val deviceStatusPayload = JSONObject().apply {
+                put("created_at", receivedAt.toString())
+                put("uploaderBattery", latestPumpSnapshot.batteryPercent?.value)
+                put("pump", JSONObject().apply {
+                    put("battery", JSONObject().apply { put("percent", latestPumpSnapshot.batteryPercent?.value) })
+                    put("iob", JSONObject().apply { put("bolusiob", latestPumpSnapshot.iobUnits?.value) })
+                    put("reservoir", latestPumpSnapshot.cartridgeUnits?.value)
+                    put("basal", latestPumpSnapshot.basalUnitsPerHour?.value)
+                })
+                put("cgm", JSONObject().apply {
+                    put("sgv", latestPumpSnapshot.sgvMgdl?.value)
+                })
+                put("controlx2ReceivedAt", JSONObject().apply {
+                    put("battery", latestPumpSnapshot.batteryPercent?.receivedAt?.toString())
+                    put("iob", latestPumpSnapshot.iobUnits?.receivedAt?.toString())
+                    put("reservoir", latestPumpSnapshot.cartridgeUnits?.receivedAt?.toString())
+                    put("basal", latestPumpSnapshot.basalUnitsPerHour?.receivedAt?.toString())
+                    put("sgv", latestPumpSnapshot.sgvMgdl?.receivedAt?.toString())
+                })
+            }.toString()
+            broadcaster.sendDeviceStatus(deviceStatusPayload, config.pumpDeviceStatusMinimumIntervalSeconds)
+        }
+
+        if (config.sendTreatments && category == StatusCategory.TREATMENT) {
+            val treatmentPayload = when (event) {
+                is DispatchEvent.TreatmentInitiated -> JSONArray().put(
+                    JSONObject().apply {
+                        put("eventType", "Bolus")
+                        put("created_at", receivedAt.toString())
+                        put("notes", "ControlX2 bolus initiated bolusId=${event.bolusId} status=${event.status}")
+                    }
+                ).toString()
+
+                is DispatchEvent.TreatmentStatus -> JSONArray().put(
+                    JSONObject().apply {
+                        put("eventType", "Bolus")
+                        put("created_at", event.timestamp.toString())
+                        put("insulin", InsulinUnit.from1000To1(event.requestedVolumeMilli))
+                        put("notes", "ControlX2 bolus status bolusId=${event.bolusId} status=${event.status}")
+                    }
+                ).toString()
+
+                else -> null
+            }
+            if (treatmentPayload != null) {
+                broadcaster.sendTreatments(
+                    treatmentsJsonString = treatmentPayload,
+                    minimumIntervalSeconds = config.treatmentsMinimumIntervalSeconds,
+                    alsoSendNewFood = true
+                )
+            }
+        }
+
+        if (config.sendStatusLine && category == StatusCategory.PUMP_STATUS) {
+            val statusline = buildString {
+                append("Pump")
+                latestPumpSnapshot.sgvMgdl?.value?.let { append(" SGV:$it") }
+                latestPumpSnapshot.iobUnits?.value?.let { append(" IOB:${twoDecimalPlaces(it)}u") }
+                latestPumpSnapshot.cartridgeUnits?.value?.let { append(" Cart:${it}u") }
+                latestPumpSnapshot.basalUnitsPerHour?.value?.let { append(" Basal:${twoDecimalPlaces(it)}u/h") }
+                latestPumpSnapshot.batteryPercent?.value?.let { append(" Batt:${it}%") }
+            }
+            broadcaster.sendExternalStatusline(statusline, config.statusLineMinimumIntervalSeconds)
+        }
+    }
+
+    private fun updateSnapshot(event: DispatchEvent, receivedAt: Instant): StatusCategory {
+        return when (event) {
+            is DispatchEvent.PumpBattery -> {
+                latestPumpSnapshot.batteryPercent = TimedPumpValue(event.percent, receivedAt)
+                StatusCategory.PUMP_STATUS
+            }
+            is DispatchEvent.PumpIob -> {
+                latestPumpSnapshot.iobUnits = TimedPumpValue(event.units, receivedAt)
+                StatusCategory.PUMP_STATUS
+            }
+            is DispatchEvent.PumpReservoir -> {
+                latestPumpSnapshot.cartridgeUnits = TimedPumpValue(event.units, receivedAt)
+                StatusCategory.PUMP_STATUS
+            }
+            is DispatchEvent.PumpBasal -> {
+                latestPumpSnapshot.basalUnitsPerHour = TimedPumpValue(event.unitsPerHour, receivedAt)
+                StatusCategory.PUMP_STATUS
+            }
+            is DispatchEvent.CgmSgv -> {
+                latestPumpSnapshot.sgvMgdl = TimedPumpValue(event.mgdl, receivedAt)
+                StatusCategory.PUMP_STATUS
+            }
+            is DispatchEvent.TreatmentInitiated,
+            is DispatchEvent.TreatmentStatus -> StatusCategory.TREATMENT
+            is DispatchEvent.Other -> StatusCategory.OTHER
+        }
+    }
+
+    private fun Message.toDispatchEvent(): DispatchEvent {
+        return when (this) {
+            is CurrentBatteryAbstractResponse -> DispatchEvent.PumpBattery(batteryPercent)
+            is ControlIQIOBResponse -> DispatchEvent.PumpIob(InsulinUnit.from1000To1(pumpDisplayedIOB))
+            is InsulinStatusResponse -> DispatchEvent.PumpReservoir(currentInsulinAmount)
+            is CurrentBasalStatusResponse -> DispatchEvent.PumpBasal(InsulinUnit.from1000To1(currentBasalRate))
+            is CurrentEGVGuiDataResponse -> DispatchEvent.CgmSgv(cgmReading)
+            is InitiateBolusResponse -> DispatchEvent.TreatmentInitiated(bolusId, statusType.toString())
+            is CurrentBolusStatusResponse -> DispatchEvent.TreatmentStatus(
+                bolusId = bolusId,
+                requestedVolumeMilli = requestedVolume,
+                status = status.toString(),
+                timestamp = timestampInstant
+            )
+            else -> DispatchEvent.Other
+        }
+    }
+
+    private enum class StatusCategory {
+        PUMP_STATUS,
+        TREATMENT,
+        OTHER
+    }
+}

--- a/mobile/src/test/java/com/jwoglom/controlx2/sync/xdrip/XdripBroadcastSenderTest.kt
+++ b/mobile/src/test/java/com/jwoglom/controlx2/sync/xdrip/XdripBroadcastSenderTest.kt
@@ -1,0 +1,56 @@
+package com.jwoglom.controlx2.sync.xdrip
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class XdripBroadcastSenderTest {
+    @Test
+    fun sendSgv_suppressesDuplicatePayloads() {
+        val sent = mutableListOf<Triple<String, String, String>>()
+        var now = 1000L
+        val sender = XdripBroadcastSender(
+            sendBroadcastFn = { action, extra, payload -> sent.add(Triple(action, extra, payload)) },
+            nowMillisFn = { now }
+        )
+
+        assertTrue(sender.sendSgv("[{\"sgv\":100}]"))
+        assertFalse(sender.sendSgv("[{\"sgv\":100}]"))
+
+        assertEquals(1, sent.size)
+        assertEquals(XdripBroadcastSender.ACTION_NEW_SGV, sent[0].first)
+    }
+
+    @Test
+    fun sendDeviceStatus_obeysMinimumInterval() {
+        val sent = mutableListOf<Triple<String, String, String>>()
+        var now = 1000L
+        val sender = XdripBroadcastSender(
+            sendBroadcastFn = { action, extra, payload -> sent.add(Triple(action, extra, payload)) },
+            nowMillisFn = { now }
+        )
+
+        assertTrue(sender.sendDeviceStatus("{\"a\":1}", minimumIntervalSeconds = 5))
+        now = 3000L
+        assertFalse(sender.sendDeviceStatus("{\"a\":2}", minimumIntervalSeconds = 5))
+        now = 7000L
+        assertTrue(sender.sendDeviceStatus("{\"a\":2}", minimumIntervalSeconds = 5))
+
+        assertEquals(2, sent.size)
+    }
+
+    @Test
+    fun sendTreatments_sendsNewFoodWhenEnabled() {
+        val sent = mutableListOf<Triple<String, String, String>>()
+        val sender = XdripBroadcastSender(
+            sendBroadcastFn = { action, extra, payload -> sent.add(Triple(action, extra, payload)) }
+        )
+
+        assertTrue(sender.sendTreatments("[{\"eventType\":\"Bolus\"}]", alsoSendNewFood = true))
+
+        assertEquals(2, sent.size)
+        assertEquals(XdripBroadcastSender.ACTION_NEW_TREATMENT, sent[0].first)
+        assertEquals(XdripBroadcastSender.ACTION_NEW_FOOD, sent[1].first)
+    }
+}

--- a/mobile/src/test/java/com/jwoglom/controlx2/sync/xdrip/XdripMessageDispatcherTest.kt
+++ b/mobile/src/test/java/com/jwoglom/controlx2/sync/xdrip/XdripMessageDispatcherTest.kt
@@ -1,0 +1,83 @@
+package com.jwoglom.controlx2.sync.xdrip
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+
+class XdripMessageDispatcherTest {
+    private class FakeBroadcaster : XdripBroadcaster {
+        val sgvPayloads = mutableListOf<String>()
+        val deviceStatusPayloads = mutableListOf<String>()
+        val treatmentPayloads = mutableListOf<String>()
+        val statuslinePayloads = mutableListOf<String>()
+
+        override fun sendSgv(sgvsJsonArrayString: String, minimumIntervalSeconds: Int?) =
+            sgvPayloads.add(sgvsJsonArrayString)
+
+        override fun sendDeviceStatus(deviceStatusJsonString: String, minimumIntervalSeconds: Int?) =
+            deviceStatusPayloads.add(deviceStatusJsonString)
+
+        override fun sendTreatments(
+            treatmentsJsonString: String,
+            minimumIntervalSeconds: Int?,
+            alsoSendNewFood: Boolean
+        ) = treatmentPayloads.add(treatmentsJsonString)
+
+        override fun sendExternalStatusline(statusline: String, minimumIntervalSeconds: Int?) =
+            statuslinePayloads.add(statusline)
+    }
+
+    @Test
+    fun onEvent_pumpStatusIncludesPerFieldReceivedTimestamps() {
+        val broadcaster = FakeBroadcaster()
+        var now = Instant.parse("2026-01-01T00:00:00Z")
+        val dispatcher = XdripMessageDispatcher(
+            broadcaster = broadcaster,
+            configProvider = { XdripSyncConfig(enabled = true) },
+            nowProvider = { now }
+        )
+
+        dispatcher.onEvent(DispatchEvent.PumpBattery(50))
+        now = Instant.parse("2026-01-01T00:01:00Z")
+        dispatcher.onEvent(DispatchEvent.CgmSgv(120))
+
+        val payload = JSONObject(broadcaster.deviceStatusPayloads.last())
+        val receivedAt = payload.getJSONObject("controlx2ReceivedAt")
+        assertEquals("2026-01-01T00:00:00Z", receivedAt.getString("battery"))
+        assertEquals("2026-01-01T00:01:00Z", receivedAt.getString("sgv"))
+    }
+
+    @Test
+    fun onEvent_disabledConfigSkipsAllBroadcasts() {
+        val broadcaster = FakeBroadcaster()
+        val dispatcher = XdripMessageDispatcher(
+            broadcaster = broadcaster,
+            configProvider = { XdripSyncConfig(enabled = false) }
+        )
+
+        dispatcher.onEvent(DispatchEvent.CgmSgv(120))
+        dispatcher.onEvent(DispatchEvent.PumpBattery(55))
+
+        assertTrue(broadcaster.sgvPayloads.isEmpty())
+        assertTrue(broadcaster.deviceStatusPayloads.isEmpty())
+        assertTrue(broadcaster.statuslinePayloads.isEmpty())
+    }
+
+    @Test
+    fun onEvent_treatmentEventProducesTreatmentPayload() {
+        val broadcaster = FakeBroadcaster()
+        val dispatcher = XdripMessageDispatcher(
+            broadcaster = broadcaster,
+            configProvider = { XdripSyncConfig(enabled = true) },
+            nowProvider = { Instant.parse("2026-01-02T03:04:05Z") }
+        )
+
+        dispatcher.onEvent(DispatchEvent.TreatmentInitiated(bolusId = 77, status = "SUCCESS"))
+
+        val treatmentJson = JSONObject(broadcaster.treatmentPayloads.single().removePrefix("[").removeSuffix("]"))
+        assertEquals("Bolus", treatmentJson.getString("eventType"))
+        assertEquals(true, treatmentJson.getString("notes").contains("bolusId=77"))
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide xDrip-compatible broadcasts for CGM, pump status, treatments, and a concise status line so external apps like xDrip/dexDrip can consume ControlX2 data.
- Reduce noisy or duplicate broadcasts by caching payloads and enforcing configurable minimum intervals.
- Surface pump/payload events (battery, IOB, reservoir, basal, SGV, and bolus events) to an xDrip-friendly pipeline for syncing and external status updates.

### Description
- Introduces `XdripBroadcastSender` implementing `XdripBroadcaster` to send broadcast `Intent`s and perform duplicate-suppression and minimum-interval caching logic. 
- Adds `XdripMessageDispatcher` to translate pump `Message` objects into dispatch events, maintain a latest-pump snapshot with per-field timestamps, and emit SGV, device status, treatments, and external statusline payloads based on `XdripSyncConfig`.
- Wires the dispatcher into the pump flow by instantiating `XdripMessageDispatcher` in `CommService.Pump` and calling `onReceiveMessage` for incoming `Message`s. 
- Adds unit tests `XdripBroadcastSenderTest` and `XdripMessageDispatcherTest` to cover cache suppression, minimum-interval behavior, multi-action treatment sends, and payload contents including per-field received timestamps.

### Testing
- Ran `XdripBroadcastSenderTest` which verifies duplicate suppression, minimum-interval enforcement, and `ACTION_NEW_FOOD` emission, and all assertions passed. 
- Ran `XdripMessageDispatcherTest` which verifies disabled config behavior, per-field received timestamps in device status payloads, and treatment payload content, and all assertions passed. 
- The new dispatcher was exercised in unit tests and wired into `CommService` for runtime dispatching; no automated integration tests were run in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b65146880c832c8bdfcf6c94d07e64)