### PR TITLE
Add xDrip settings section in mobile app

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/Landing.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/Landing.kt
@@ -87,6 +87,7 @@ import com.jwoglom.controlx2.presentation.screens.sections.Settings
 import com.jwoglom.controlx2.presentation.screens.sections.TempRateWindow
 import com.jwoglom.controlx2.presentation.screens.sections.SoundSettingsActions
 import com.jwoglom.controlx2.presentation.screens.sections.NightscoutSettings
+import com.jwoglom.controlx2.presentation.screens.sections.XdripSettings
 import com.jwoglom.controlx2.presentation.screens.sections.dashboardCommands
 import com.jwoglom.controlx2.presentation.screens.sections.dashboardFields
 import com.jwoglom.controlx2.presentation.screens.sections.resetBolusDataStoreState
@@ -450,6 +451,9 @@ fun Landing(
                                 },
                                 navigateToNightscoutSettings = {
                                     selectedItem = LandingSection.NIGHTSCOUT_SETTINGS
+                                },
+                                navigateToXdripSettings = {
+                                    selectedItem = LandingSection.XDRIP_SETTINGS
                                 }
                             )
                         }
@@ -458,6 +462,13 @@ fun Landing(
                                 innerPadding = innerPadding,
                                 navController = navController,
                                 pumpSid = ds.pumpSid.observeAsState().value ?: 0
+                            )
+                        }
+                        LandingSection.XDRIP_SETTINGS -> {
+                            XdripSettings(
+                                innerPadding = innerPadding,
+                                navController = navController,
+                                sendMessage = sendMessage
                             )
                         }
                     }
@@ -562,6 +573,7 @@ enum class LandingSection(val label: String, val icon: ImageVector, val showInNa
     SETTINGS("Settings", Icons.Filled.Settings, true),
     DEBUG("Settings", Icons.Filled.Settings, false),
     NIGHTSCOUT_SETTINGS("Settings", Icons.Filled.Settings, false),
+    XDRIP_SETTINGS("Settings", Icons.Filled.Settings, false),
     ;
 }
 

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Settings.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Settings.kt
@@ -74,7 +74,8 @@ fun Settings(
     sendMessage: (String, ByteArray) -> Unit,
     sendPumpCommands: (SendType, List<Message>) -> Unit,
     navigateToDebugOptions: () -> Unit = {},
-    navigateToNightscoutSettings: () -> Unit = {}
+    navigateToNightscoutSettings: () -> Unit = {},
+    navigateToXdripSettings: () -> Unit = {}
 ) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
@@ -262,6 +263,23 @@ fun Settings(
                     },
                     modifier = Modifier.clickable {
                         navigateToNightscoutSettings()
+                    }
+                )
+                Divider()
+            }
+
+            item {
+                ListItem(
+                    headlineContent = { Text("xDrip") },
+                    supportingContent = { Text("Configure xDrip broadcasts for pump and CGM data.") },
+                    leadingContent = {
+                        Icon(
+                            Icons.Filled.Refresh,
+                            contentDescription = "xDrip icon",
+                        )
+                    },
+                    modifier = Modifier.clickable {
+                        navigateToXdripSettings()
                     }
                 )
                 Divider()

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/XdripSettings.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/XdripSettings.kt
@@ -1,0 +1,227 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.jwoglom.controlx2.presentation.screens.sections
+
+import android.content.Context
+import android.widget.Toast
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BugReport
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import com.jwoglom.controlx2.presentation.components.HeaderLine
+import com.jwoglom.controlx2.sync.xdrip.XdripBroadcastSender
+import com.jwoglom.controlx2.sync.xdrip.XdripPayloadGroup
+import com.jwoglom.controlx2.sync.xdrip.XdripSyncConfig
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.json.JSONArray
+import org.json.JSONObject
+import java.time.Instant
+
+@Composable
+fun XdripSettings(
+    innerPadding: PaddingValues = PaddingValues(),
+    navController: NavHostController? = null,
+    sendMessage: (String, ByteArray) -> Unit,
+) {
+    val context = LocalContext.current
+    val prefs = context.getSharedPreferences("controlx2", Context.MODE_PRIVATE)
+    val coroutineScope = rememberCoroutineScope()
+
+    var config by remember { mutableStateOf(XdripSyncConfig.load(prefs)) }
+
+    fun saveConfig(newConfig: XdripSyncConfig, showToastText: String? = null) {
+        config = newConfig
+        XdripSyncConfig.save(prefs, newConfig)
+
+        coroutineScope.launch {
+            delay(250)
+            sendMessage("/to-phone/force-reload", "".toByteArray())
+            delay(250)
+            sendMessage("/to-phone/app-reload", "".toByteArray())
+        }
+
+        if (showToastText != null) {
+            Toast.makeText(context, showToastText, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    fun togglePayload(payloadGroup: XdripPayloadGroup) {
+        val payloadEnabled = config.isPayloadEnabled(payloadGroup)
+        saveConfig(config.withPayloadEnabled(payloadGroup, !payloadEnabled))
+    }
+
+    LazyColumn(
+        contentPadding = innerPadding,
+        verticalArrangement = Arrangement.spacedBy(0.dp),
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 0.dp),
+        content = {
+            item {
+                HeaderLine("xDrip Settings")
+                Divider()
+            }
+
+            item {
+                ListItem(
+                    headlineContent = {
+                        Text(if (config.enabled) "Disable xDrip Sync" else "Enable xDrip Sync")
+                    },
+                    supportingContent = {
+                        Text(
+                            if (config.enabled) {
+                                "Stops sending pump and CGM updates to xDrip"
+                            } else {
+                                "Enables xDrip broadcasts for selected payload groups"
+                            }
+                        )
+                    },
+                    leadingContent = {
+                        Icon(
+                            if (config.enabled) Icons.Filled.Close else Icons.Filled.Check,
+                            contentDescription = if (config.enabled) "Disable" else "Enable"
+                        )
+                    },
+                    trailingContent = {
+                        Switch(
+                            checked = config.enabled,
+                            onCheckedChange = { saveConfig(config.copy(enabled = it)) }
+                        )
+                    },
+                    modifier = Modifier.clickable {
+                        val newEnabled = !config.enabled
+                        saveConfig(
+                            config.copy(enabled = newEnabled),
+                            if (newEnabled) "xDrip sync enabled" else "xDrip sync disabled"
+                        )
+                    }
+                )
+                Divider()
+            }
+
+            item {
+                XdripPayloadToggleItem(
+                    title = "Send SGV",
+                    subtitle = "Broadcast current glucose readings to xDrip",
+                    enabled = config.sendCgmSgv,
+                    onToggle = { togglePayload(XdripPayloadGroup.CGM) }
+                )
+                Divider()
+            }
+
+            item {
+                XdripPayloadToggleItem(
+                    title = "Send Device Status",
+                    subtitle = "Broadcast battery, IOB, cartridge, and basal status",
+                    enabled = config.sendPumpDeviceStatus,
+                    onToggle = { togglePayload(XdripPayloadGroup.PUMP_DEVICE_STATUS) }
+                )
+                Divider()
+            }
+
+            item {
+                XdripPayloadToggleItem(
+                    title = "Send Treatments",
+                    subtitle = "Broadcast bolus treatments to xDrip",
+                    enabled = config.sendTreatments,
+                    onToggle = { togglePayload(XdripPayloadGroup.TREATMENTS) }
+                )
+                Divider()
+            }
+
+            item {
+                XdripPayloadToggleItem(
+                    title = "Send Statusline",
+                    subtitle = "Broadcast one-line pump status text",
+                    enabled = config.sendStatusLine,
+                    onToggle = { togglePayload(XdripPayloadGroup.STATUS_LINE) }
+                )
+                Divider()
+            }
+
+            item {
+                ListItem(
+                    headlineContent = { Text("Send diagnostics test payload") },
+                    supportingContent = {
+                        Text("Sends one-shot test SGV and statusline broadcast intents")
+                    },
+                    leadingContent = {
+                        Icon(
+                            Icons.Filled.BugReport,
+                            contentDescription = "Diagnostics icon"
+                        )
+                    },
+                    modifier = Modifier.clickable {
+                        sendDiagnosticsPayload(context)
+                    }
+                )
+                Divider()
+            }
+        }
+    )
+}
+
+@Composable
+private fun XdripPayloadToggleItem(
+    title: String,
+    subtitle: String,
+    enabled: Boolean,
+    onToggle: () -> Unit
+) {
+    ListItem(
+        headlineContent = { Text(title) },
+        supportingContent = { Text(subtitle) },
+        trailingContent = {
+            Switch(
+                checked = enabled,
+                onCheckedChange = { onToggle() }
+            )
+        },
+        modifier = Modifier.clickable { onToggle() }
+    )
+}
+
+private fun sendDiagnosticsPayload(context: Context) {
+    val now = Instant.now()
+    val sender = XdripBroadcastSender(context)
+    val sgvSent = sender.sendSgv(
+        JSONArray().put(
+            JSONObject().apply {
+                put("sgv", 123)
+                put("date", now.toEpochMilli())
+                put("dateString", now.toString())
+            }
+        ).toString()
+    )
+    val statusSent = sender.sendExternalStatusline("ControlX2 test statusline @ ${now}")
+
+    val message = buildString {
+        append("Diagnostics sent")
+        append(if (sgvSent) " (SGV OK" else " (SGV skipped")
+        append(if (statusSent) ", statusline OK)" else ", statusline skipped)")
+    }
+    Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+}


### PR DESCRIPTION
### Motivation

- Expose xDrip broadcast configuration in the mobile UI so users can enable/disable the integration and pick which payload groups are sent (SGV, device status, treatments, statusline). 
- Provide a diagnostics action for one-shot test broadcasts and mirror the existing integration UX (persist config and trigger service/app reloads) used by Nightscout.

### Description

- Add a new Compose screen `XdripSettings` at `mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/XdripSettings.kt` that mirrors the Nightscout settings layout and provides:
  - master enable/disable toggle persisted via `XdripSyncConfig.load/save`,
  - individual switches for `SGV`, `Device Status`, `Treatments`, and `Statusline` persisted through `XdripSyncConfig`,
  - a diagnostics action which sends a test SGV and a test statusline using `XdripBroadcastSender` and reports send/skipped via `Toast`.
- Wire navigation from `Settings` by adding a new callback `navigateToXdripSettings` and an `xDrip` row in `Settings.kt` to open the screen.
- Hook the new screen into `Landing` by importing `XdripSettings`, adding `LandingSection.XDRIP_SETTINGS`, and rendering the `XdripSettings` composable when that section is selected so in-app navigation matches other integration pages.
- Config changes trigger the same refresh pattern as other integrations by calling `/to-phone/force-reload` and `/to-phone/app-reload` after saving `XdripSyncConfig`.

### Testing

- Ran the repo setup helper `./.codex/setup.sh` to provision a local Android SDK; the setup completed successfully.
- Attempted to run a Kotlin compile with `./gradlew :mobile:compileDebugKotlin --no-daemon` to validate compilation, but the Gradle invocation did not produce a usable completion in this execution session so a full build verification could not be completed here.
- All changes were committed locally (`Add xDrip settings screen and landing navigation`) and a PR metadata entry was created; unit/instrumentation tests were not executed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6e21df4d4832ca18befb0a4e8265b)