### PR TITLE
Harden Codex Android build bootstrap and enforce full Kotlin compile

### DIFF
--- a/.codex/build.sh
+++ b/.codex/build.sh
@@ -5,10 +5,9 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SDK_ROOT="${ANDROID_SDK_ROOT:-$REPO_ROOT/.android-sdk}"
 CMDLINE_DIR="$SDK_ROOT/cmdline-tools/latest"
 
-if [[ ! -x "$CMDLINE_DIR/bin/sdkmanager" ]]; then
-  echo "Android SDK command-line tools not found at $CMDLINE_DIR." >&2
-  echo "Run .codex/setup.sh first." >&2
-  exit 1
+if [[ ! -x "$CMDLINE_DIR/bin/sdkmanager" || ! -f "$REPO_ROOT/local.properties" ]]; then
+  echo "Bootstrapping Android SDK and local.properties via .codex/setup.sh"
+  "$REPO_ROOT/.codex/setup.sh"
 fi
 
 export ANDROID_SDK_ROOT="$SDK_ROOT"
@@ -17,4 +16,10 @@ export PATH="$CMDLINE_DIR/bin:$SDK_ROOT/platform-tools:$PATH"
 export GRADLE_USER_HOME="${GRADLE_USER_HOME:-$REPO_ROOT/.gradle-home}"
 
 cd "$REPO_ROOT"
-./gradlew :wear:compileDebugKotlin --console=plain --no-daemon
+./gradlew \
+  :shared:compileDebugKotlin \
+  :mobile:compileDebugKotlin \
+  :wear:compileDebugKotlin \
+  --console=plain \
+  --info \
+  --no-daemon

--- a/.codex/test.sh
+++ b/.codex/test.sh
@@ -5,10 +5,9 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SDK_ROOT="${ANDROID_SDK_ROOT:-$REPO_ROOT/.android-sdk}"
 CMDLINE_DIR="$SDK_ROOT/cmdline-tools/latest"
 
-if [[ ! -x "$CMDLINE_DIR/bin/sdkmanager" ]]; then
-  echo "Android SDK command-line tools not found at $CMDLINE_DIR." >&2
-  echo "Run .codex/setup.sh first." >&2
-  exit 1
+if [[ ! -x "$CMDLINE_DIR/bin/sdkmanager" || ! -f "$REPO_ROOT/local.properties" ]]; then
+  echo "Bootstrapping Android SDK and local.properties via .codex/setup.sh"
+  "$REPO_ROOT/.codex/setup.sh"
 fi
 
 export ANDROID_SDK_ROOT="$SDK_ROOT"


### PR DESCRIPTION
### Motivation
- Gradle invocations from the Codex helpers could hang or produce incomplete verification when the repo-local Android SDK or `local.properties` were missing. 
- The helper `build` flow only compiled `:wear`, so full-module Kotlin compile checks were not being validated. 
- Make the helper scripts resilient so CI-like runs always produce a usable, end-to-end compile verification.

### Description
- Update `.codex/build.sh` to auto-run `.codex/setup.sh` when the SDK command-line tools or `local.properties` are missing, ensuring the environment is bootstrapped before Gradle runs. 
- Change `.codex/build.sh` to compile all modules by running `:shared:compileDebugKotlin`, `:mobile:compileDebugKotlin`, and `:wear:compileDebugKotlin` and add `--info` for better progress visibility. 
- Apply the same bootstrap check to `.codex/test.sh` so unit test runs also self-bootstrap in fresh containers. 
- Commit the changes and update the helper scripts so local developer and automated runs are robust without manual pre-steps.

### Testing
- Ran `.codex/build.sh` in the environment and confirmed the script bootstraps the SDK when needed and the Gradle task graph included `:shared:compileDebugKotlin`, `:mobile:compileDebugKotlin`, and `:wear:compileDebugKotlin`. 
- Observed the build progress logs (with `--info`) showing tasks being evaluated and Kotlin compile tasks executed or marked up-to-date as appropriate. 
- No automated test failures were produced during these runs and the script changes were committed (`git commit` completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6e9cc8808832ca9d31282c3fdc36c)