### PR TITLE
Support locale decimal separators and Enter/Done submit for Bolus inputs

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/BolusWindow.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/BolusWindow.kt
@@ -282,6 +282,28 @@ fun BolusWindow(
         }
     }
 
+    fun requestBolusDeliveryFromInputSubmit() {
+        if (refreshing) {
+            return
+        }
+
+        if (validBolus(
+                params = dataStore.bolusCurrentParameters.value,
+                maxBolusAmount1000 = dataStore.bolusCalcDataSnapshot.value?.maxBolusAmount?.toLong()
+            )
+        ) {
+            dataStore.bolusFinalConditions.value =
+                bolusCalcDecision(dataStore.bolusCalculatorBuilder.value, dataStore.bolusConditionsExcluded.value)?.conditions
+
+            val pair = bolusCalcParameters(dataStore.bolusCalculatorBuilder.value, dataStore.bolusConditionsExcluded.value)
+            dataStore.bolusFinalParameters.value = pair.first
+            dataStore.bolusFinalCalcUnits.value = pair.second
+
+            showPermissionCheckDialog = true
+            sendPumpCommands(SendType.BUST_CACHE, listOf(BolusPermissionRequest()))
+        }
+    }
+
     LaunchedEffect (cgmReading) {
         refresh()
     }
@@ -309,7 +331,10 @@ fun BolusWindow(
         onGlucoseChanged = {
             dataStore.bolusGlucoseRawValue.value = it
             glucoseHumanEntered = if (it == "") null else it.toIntOrNull()
-        }
+        },
+        onSubmitRequested = {
+            requestBolusDeliveryFromInputSubmit()
+        },
     )
 
     BolusConditionPromptRegion(

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/DecimalOutlinedText.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/DecimalOutlinedText.kt
@@ -1,6 +1,7 @@
 package com.jwoglom.controlx2.presentation.screens.sections.components
 
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -14,10 +15,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import com.jwoglom.controlx2.presentation.util.onFocusSelectAll
-import com.jwoglom.controlx2.shared.util.twoDecimalPlaces
+import java.text.DecimalFormatSymbols
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -25,6 +28,7 @@ fun DecimalOutlinedText(
     title: String,
     value: String?,
     onValueChange: (String) -> Unit,
+    onSubmitRequested: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     var error = false
@@ -33,6 +37,7 @@ fun DecimalOutlinedText(
     var textFieldValue = remember {
         mutableStateOf(TextFieldValue(value ?: ""))
     }
+    val localeDecimalSeparator = DecimalFormatSymbols.getInstance(Locale.getDefault()).decimalSeparator
 
     LaunchedEffect (value) {
         textFieldValue.value = textFieldValue.value.copy(text = value ?: "")
@@ -43,8 +48,23 @@ fun DecimalOutlinedText(
         onValueChange = { it: TextFieldValue ->
             textFieldValue.value = it
             val text = it.text
-            var filtered = text.filter { (it in '0'..'9') || it == '.' }
-            val dotIndex = filtered.lastIndexOf('.')
+
+            val acceptedDecimalSeparators = setOf('.', ',', localeDecimalSeparator)
+            val normalized = buildString {
+                var decimalSeen = false
+                text.forEach { char ->
+                    when {
+                        char in '0'..'9' -> append(char)
+                        char in acceptedDecimalSeparators && !decimalSeen -> {
+                            append('.')
+                            decimalSeen = true
+                        }
+                    }
+                }
+            }
+
+            var filtered = normalized
+            val dotIndex = filtered.indexOf('.')
             if (dotIndex >= 0 && filtered.length - dotIndex > decimalPlaces + 1) {
                 filtered = filtered.substring(0, dotIndex + decimalPlaces + 1)
             }
@@ -55,11 +75,18 @@ fun DecimalOutlinedText(
             autoCorrect = false,
             capitalization = KeyboardCapitalization.None,
             keyboardType = KeyboardType.Number,
+            imeAction = ImeAction.Done,
+        ),
+        keyboardActions = KeyboardActions(
+            onDone = {
+                onSubmitRequested?.invoke()
+            }
         ),
         label = {
             Text(title)
         },
         isError = error,
+        singleLine = true,
         colors = OutlinedTextFieldDefaults.colors(
             focusedTextColor = MaterialTheme.colorScheme.onSurface,
             unfocusedTextColor = MaterialTheme.colorScheme.onSurface

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/IntegerOutlinedText.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/IntegerOutlinedText.kt
@@ -1,6 +1,7 @@
 package com.jwoglom.controlx2.presentation.screens.sections.components
 
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -10,6 +11,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -18,6 +20,7 @@ fun IntegerOutlinedText(
     title: String,
     value: String?,
     onValueChange: (String) -> Unit,
+    onSubmitRequested: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     var error = false
@@ -36,11 +39,18 @@ fun IntegerOutlinedText(
             autoCorrect = false,
             capitalization = KeyboardCapitalization.None,
             keyboardType = KeyboardType.Number,
+            imeAction = ImeAction.Done,
+        ),
+        keyboardActions = KeyboardActions(
+            onDone = {
+                onSubmitRequested?.invoke()
+            }
         ),
         label = {
             Text(title)
         },
         isError = error,
+        singleLine = true,
         colors = OutlinedTextFieldDefaults.colors(
             focusedTextColor = MaterialTheme.colorScheme.onSurface,
             unfocusedTextColor = MaterialTheme.colorScheme.onSurface

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/bolus/BolusEntryFormRegion.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/bolus/BolusEntryFormRegion.kt
@@ -28,6 +28,7 @@ fun BolusEntryFormRegion(
     onUnitsFocusChanged: (Boolean) -> Unit,
     onCarbsChanged: (String) -> Unit,
     onGlucoseChanged: (String) -> Unit,
+    onSubmitRequested: () -> Unit,
 ) {
     val dataStore = LocalDataStore.current
     val snapshot = BolusEntrySnapshot(
@@ -43,6 +44,7 @@ fun BolusEntryFormRegion(
                 title = unitsSubtitle,
                 value = snapshot.unitsValue,
                 onValueChange = onUnitsChanged,
+                onSubmitRequested = onSubmitRequested,
                 modifier = Modifier.onFocusChanged { onUnitsFocusChanged(it.isFocused) }
             )
         }
@@ -58,7 +60,8 @@ fun BolusEntryFormRegion(
             IntegerOutlinedText(
                 title = carbsSubtitle,
                 value = snapshot.carbsValue,
-                onValueChange = onCarbsChanged
+                onValueChange = onCarbsChanged,
+                onSubmitRequested = onSubmitRequested
             )
         }
 
@@ -70,7 +73,8 @@ fun BolusEntryFormRegion(
             IntegerOutlinedText(
                 title = glucoseSubtitle,
                 value = snapshot.glucoseValue,
-                onValueChange = onGlucoseChanged
+                onValueChange = onGlucoseChanged,
+                onSubmitRequested = onSubmitRequested
             )
         }
     }


### PR DESCRIPTION
### Motivation
- Users in comma-decimal locales expect `,` to work as a decimal separator for bolus units, and the IME Enter/Done key should submit the form rather than inserting a newline.
- The bolus flow should accept locale-friendly input and treat an Enter/Done press as the same guarded submit path the Deliver button uses.

### Description
- `DecimalOutlinedText` now accepts `.` `,` and the device locale decimal separator, normalizes the first decimal separator to `.` for parsing, and keeps at most two fractional digits. (`DecimalOutlinedText.kt`)
- Both `DecimalOutlinedText` and `IntegerOutlinedText` set `imeAction = ImeAction.Done`, add `keyboardActions` to handle `onDone`, and use `singleLine = true` to prevent multiline input. (`DecimalOutlinedText.kt`, `IntegerOutlinedText.kt`)
- `BolusEntryFormRegion` was extended to propagate an `onSubmitRequested` callback from each input field. (`BolusEntryFormRegion.kt`)
- `BolusWindow` now listens for input-submit events via a new `requestBolusDeliveryFromInputSubmit()` helper that prepares final parameters and issues the same permission-check/bolus-request path (`BolusPermissionRequest`) used by the Deliver button, guarded by existing validity and refresh checks. (`BolusWindow.kt`)

### Testing
- Ran the repository build flow and Kotlin compilation: `./.codex/build.sh` (project build flow) and `./gradlew :mobile:compileDebugKotlin --console=plain --no-daemon`, both completed with **BUILD SUCCESSFUL**; deprecation warnings were observed but are unrelated to these changes.
- No unit tests were added or modified; changes were validated by a successful compile of the mobile module.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b700f41d28832cad014bccfd0dd0f4)