### PR TITLE
Add Nightscout Announcement support to API client, parser, model, and tests

### DIFF
--- a/mobile/src/androidTest/java/com/jwoglom/controlx2/sync/nightscout/NightscoutSyncCoordinatorTest.kt
+++ b/mobile/src/androidTest/java/com/jwoglom/controlx2/sync/nightscout/NightscoutSyncCoordinatorTest.kt
@@ -11,6 +11,7 @@ import com.jwoglom.controlx2.db.nightscout.NightscoutSyncStateDatabase
 import com.jwoglom.controlx2.sync.nightscout.api.NightscoutApi
 import com.jwoglom.controlx2.sync.nightscout.models.NightscoutEntry
 import com.jwoglom.controlx2.sync.nightscout.models.NightscoutTreatment
+import com.jwoglom.controlx2.sync.nightscout.models.NightscoutAnnouncement
 import com.jwoglom.controlx2.sync.nightscout.models.NightscoutDeviceStatus
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -279,6 +280,18 @@ class MockNightscoutApi : NightscoutApi {
         return Result.success(
             uploadedTreatments.lastOrNull { it.eventType == eventType }
         )
+    }
+
+    override suspend fun getAnnouncements(count: Int): Result<List<NightscoutAnnouncement>> {
+        return Result.success(emptyList())
+    }
+
+    override suspend fun getAnnouncementsSince(
+        sinceTimestamp: Long?,
+        sinceId: String?,
+        count: Int
+    ): Result<List<NightscoutAnnouncement>> {
+        return Result.success(emptyList())
     }
 
     fun reset() {

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/api/NightscoutAnnouncementEndpoint.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/api/NightscoutAnnouncementEndpoint.kt
@@ -1,0 +1,25 @@
+package com.jwoglom.controlx2.sync.nightscout.api
+
+import java.net.URLEncoder
+
+internal object NightscoutAnnouncementEndpoint {
+    private const val AnnouncementEventType = "Announcement"
+
+    fun latest(count: Int): String {
+        val encodedEventType = URLEncoder.encode(AnnouncementEventType, Charsets.UTF_8.name())
+        return "/api/v1/treatments?find[eventType]=$encodedEventType&count=${count.coerceAtLeast(1)}"
+    }
+
+    fun since(sinceTimestamp: Long?, sinceId: String?, count: Int): String {
+        val encodedEventType = URLEncoder.encode(AnnouncementEventType, Charsets.UTF_8.name())
+        val params = mutableListOf(
+            "find[eventType]=$encodedEventType",
+            "count=${count.coerceAtLeast(1)}"
+        )
+        sinceTimestamp?.let { params.add("find[created_at][\$gte]=$it") }
+        sinceId?.takeIf { it.isNotBlank() }?.let {
+            params.add("find[_id][\$gt]=${URLEncoder.encode(it, Charsets.UTF_8.name())}")
+        }
+        return "/api/v1/treatments?${params.joinToString("&")}"
+    }
+}

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/api/NightscoutAnnouncementParser.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/api/NightscoutAnnouncementParser.kt
@@ -1,0 +1,34 @@
+package com.jwoglom.controlx2.sync.nightscout.api
+
+import com.google.gson.Gson
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonParser
+import com.google.gson.reflect.TypeToken
+import com.jwoglom.controlx2.sync.nightscout.models.NightscoutAnnouncement
+
+internal class NightscoutAnnouncementParser(
+    private val gson: Gson
+) {
+    fun parseAnnouncements(response: String): List<NightscoutAnnouncement> {
+        if (response.isBlank()) {
+            return emptyList()
+        }
+
+        val json: JsonElement = JsonParser.parseString(response)
+        val payloadArray = when {
+            json.isJsonArray -> json.asJsonArray
+            json.isJsonObject && json.asJsonObject.has("result") && json.asJsonObject["result"].isJsonArray -> {
+                json.asJsonObject["result"].asJsonArray
+            }
+            else -> JsonArray()
+        }
+
+        if (payloadArray.size() == 0) {
+            return emptyList()
+        }
+
+        val type = object : TypeToken<List<NightscoutAnnouncement>>() {}.type
+        return gson.fromJson(payloadArray, type)
+    }
+}

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/api/NightscoutApi.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/api/NightscoutApi.kt
@@ -1,6 +1,7 @@
 package com.jwoglom.controlx2.sync.nightscout.api
 
 import com.jwoglom.controlx2.sync.nightscout.models.NightscoutDeviceStatus
+import com.jwoglom.controlx2.sync.nightscout.models.NightscoutAnnouncement
 import com.jwoglom.controlx2.sync.nightscout.models.NightscoutEntry
 import com.jwoglom.controlx2.sync.nightscout.models.NightscoutTreatment
 
@@ -40,4 +41,19 @@ interface NightscoutApi {
      * GET /api/v1/treatments?eventType=X&count=1
      */
     suspend fun getLastTreatment(eventType: String): Result<NightscoutTreatment?>
+
+    /**
+     * Get latest announcements
+     * GET /api/v1/treatments?find[eventType]=Announcement&count=N
+     */
+    suspend fun getAnnouncements(count: Int = 10): Result<List<NightscoutAnnouncement>>
+
+    /**
+     * Get announcements after a point in time and/or id marker
+     */
+    suspend fun getAnnouncementsSince(
+        sinceTimestamp: Long? = null,
+        sinceId: String? = null,
+        count: Int = 100
+    ): Result<List<NightscoutAnnouncement>>
 }

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/api/NightscoutAuthException.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/api/NightscoutAuthException.kt
@@ -1,0 +1,3 @@
+package com.jwoglom.controlx2.sync.nightscout.api
+
+class NightscoutAuthException(message: String) : Exception(message)

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/api/NightscoutClient.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/api/NightscoutClient.kt
@@ -1,9 +1,11 @@
 package com.jwoglom.controlx2.sync.nightscout.api
 
 import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
 import com.google.gson.reflect.TypeToken
 import com.jwoglom.controlx2.sync.nightscout.NightscoutApiSecretHeader
 import com.jwoglom.controlx2.sync.nightscout.hashNightscoutApiSecret
+import com.jwoglom.controlx2.sync.nightscout.models.NightscoutAnnouncement
 import com.jwoglom.controlx2.sync.nightscout.models.NightscoutDeviceStatus
 import com.jwoglom.controlx2.sync.nightscout.models.NightscoutEntry
 import com.jwoglom.controlx2.sync.nightscout.models.NightscoutTreatment
@@ -11,6 +13,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.io.BufferedReader
+import java.io.InputStream
 import java.io.InputStreamReader
 import java.io.OutputStreamWriter
 import java.net.HttpURLConnection
@@ -29,11 +32,12 @@ class NightscoutClient(
 
     private val gson = Gson()
     private val apiSecretHash: String by lazy { hashNightscoutApiSecret(apiSecret) }
+    private val announcementParser = NightscoutAnnouncementParser(gson)
 
     override suspend fun uploadEntries(entries: List<NightscoutEntry>): Result<Int> {
         return withContext(Dispatchers.IO) {
             try {
-                val response = post("/api/v1/entries", entries)
+                post("/api/v1/entries", entries)
                 Timber.d("Uploaded ${entries.size} entries to Nightscout")
                 Result.success(entries.size)
             } catch (e: Exception) {
@@ -46,7 +50,7 @@ class NightscoutClient(
     override suspend fun uploadTreatments(treatments: List<NightscoutTreatment>): Result<Int> {
         return withContext(Dispatchers.IO) {
             try {
-                val response = post("/api/v1/treatments", treatments)
+                post("/api/v1/treatments", treatments)
                 Timber.d("Uploaded ${treatments.size} treatments to Nightscout")
                 Result.success(treatments.size)
             } catch (e: Exception) {
@@ -59,7 +63,7 @@ class NightscoutClient(
     override suspend fun uploadDeviceStatus(status: NightscoutDeviceStatus): Result<Boolean> {
         return withContext(Dispatchers.IO) {
             try {
-                val response = post("/api/v1/devicestatus", listOf(status))
+                post("/api/v1/devicestatus", listOf(status))
                 Timber.d("Uploaded device status to Nightscout")
                 Result.success(true)
             } catch (e: Exception) {
@@ -97,6 +101,53 @@ class NightscoutClient(
         }
     }
 
+    override suspend fun getAnnouncements(count: Int): Result<List<NightscoutAnnouncement>> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val response = get(NightscoutAnnouncementEndpoint.latest(count))
+                Result.success(announcementParser.parseAnnouncements(response))
+            } catch (e: NightscoutAuthException) {
+                Timber.w(e, "Nightscout auth failed while fetching announcements")
+                Result.failure(e)
+            } catch (e: JsonSyntaxException) {
+                val wrapped = IllegalArgumentException("Malformed announcements response payload", e)
+                Timber.e(wrapped)
+                Result.failure(wrapped)
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to fetch announcements")
+                Result.failure(e)
+            }
+        }
+    }
+
+    override suspend fun getAnnouncementsSince(
+        sinceTimestamp: Long?,
+        sinceId: String?,
+        count: Int
+    ): Result<List<NightscoutAnnouncement>> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val endpoint = NightscoutAnnouncementEndpoint.since(
+                    sinceTimestamp = sinceTimestamp,
+                    sinceId = sinceId,
+                    count = count
+                )
+                val response = get(endpoint)
+                Result.success(announcementParser.parseAnnouncements(response))
+            } catch (e: NightscoutAuthException) {
+                Timber.w(e, "Nightscout auth failed while fetching announcements since marker")
+                Result.failure(e)
+            } catch (e: JsonSyntaxException) {
+                val wrapped = IllegalArgumentException("Malformed announcements response payload", e)
+                Timber.e(wrapped)
+                Result.failure(wrapped)
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to fetch announcements since marker")
+                Result.failure(e)
+            }
+        }
+    }
+
     private fun post(endpoint: String, body: Any): String {
         val url = URL("$baseUrl$endpoint")
         val connection = url.openConnection() as HttpURLConnection
@@ -109,24 +160,16 @@ class NightscoutClient(
             connection.connectTimeout = 30000
             connection.readTimeout = 30000
 
-            // Write body
             val writer = OutputStreamWriter(connection.outputStream)
             writer.write(gson.toJson(body))
             writer.flush()
             writer.close()
 
-            // Read response
             val responseCode = connection.responseCode
             if (responseCode in 200..299) {
-                val reader = BufferedReader(InputStreamReader(connection.inputStream))
-                val response = reader.readText()
-                reader.close()
-                response
+                readResponseBody(connection.inputStream)
             } else {
-                val errorReader = BufferedReader(InputStreamReader(connection.errorStream))
-                val error = errorReader.readText()
-                errorReader.close()
-                throw Exception("Nightscout API error ($responseCode): $error")
+                throw createHttpException(responseCode, readResponseBody(connection.errorStream))
             }
         } finally {
             connection.disconnect()
@@ -145,18 +188,28 @@ class NightscoutClient(
 
             val responseCode = connection.responseCode
             if (responseCode in 200..299) {
-                val reader = BufferedReader(InputStreamReader(connection.inputStream))
-                val response = reader.readText()
-                reader.close()
-                response
+                readResponseBody(connection.inputStream)
             } else {
-                val errorReader = BufferedReader(InputStreamReader(connection.errorStream))
-                val error = errorReader.readText()
-                errorReader.close()
-                throw Exception("Nightscout API error ($responseCode): $error")
+                throw createHttpException(responseCode, readResponseBody(connection.errorStream))
             }
         } finally {
             connection.disconnect()
+        }
+    }
+
+    private fun readResponseBody(stream: InputStream?): String {
+        if (stream == null) {
+            return ""
+        }
+        val reader = BufferedReader(InputStreamReader(stream))
+        return reader.use { it.readText() }
+    }
+
+    private fun createHttpException(responseCode: Int, errorBody: String): Exception {
+        return if (responseCode == 401 || responseCode == 403) {
+            NightscoutAuthException("Nightscout API auth failed ($responseCode): $errorBody")
+        } else {
+            Exception("Nightscout API error ($responseCode): $errorBody")
         }
     }
 }

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/models/NightscoutAnnouncement.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/models/NightscoutAnnouncement.kt
@@ -1,0 +1,27 @@
+package com.jwoglom.controlx2.sync.nightscout.models
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Nightscout announcement payload represented as a treatment entry
+ * (`eventType = "Announcement"`).
+ */
+data class NightscoutAnnouncement(
+    @SerializedName("_id")
+    val id: String? = null,
+
+    @SerializedName("eventType")
+    val eventType: String? = null,
+
+    @SerializedName(value = "notes", alternate = ["message"])
+    val message: String? = null,
+
+    @SerializedName("created_at")
+    val createdAt: String? = null,
+
+    @SerializedName("enteredBy")
+    val enteredBy: String? = null,
+
+    @SerializedName("date")
+    val date: Long? = null
+)

--- a/mobile/src/test/java/com/jwoglom/controlx2/sync/nightscout/NightscoutClientIntegrationTest.kt
+++ b/mobile/src/test/java/com/jwoglom/controlx2/sync/nightscout/NightscoutClientIntegrationTest.kt
@@ -2,6 +2,7 @@ package com.jwoglom.controlx2.sync.nightscout
 
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import com.jwoglom.controlx2.sync.nightscout.api.NightscoutAuthException
 import com.jwoglom.controlx2.sync.nightscout.api.NightscoutClient
 import com.jwoglom.controlx2.sync.nightscout.models.NightscoutEntry
 import com.jwoglom.controlx2.sync.nightscout.models.NightscoutTreatment
@@ -412,6 +413,58 @@ class NightscoutClientIntegrationTest {
 
         assertTrue(result.isSuccess)
         assertNull(result.getOrNull())
+    }
+
+    @Test
+    fun getAnnouncements_parsesResponse() = runBlocking {
+        server.nextResponseBody = """[
+            {"_id":"ann-1","eventType":"Announcement","notes":"Nightscout maintenance window","created_at":"2024-03-15T00:00:00Z","enteredBy":"Nightscout"}
+        ]"""
+
+        val result = client.getAnnouncements(3)
+
+        assertTrue(result.isSuccess)
+        assertEquals("/api/v1/treatments?find[eventType]=Announcement&count=3", server.capturedRequests[0].path)
+        val announcements = result.getOrNull()!!
+        assertEquals(1, announcements.size)
+        assertEquals("ann-1", announcements[0].id)
+        assertEquals("Announcement", announcements[0].eventType)
+        assertEquals("Nightscout maintenance window", announcements[0].message)
+    }
+
+    @Test
+    fun getAnnouncements_returnsAuthFailureOnUnauthorized() = runBlocking {
+        server.nextResponseCode = NanoHTTPD.Response.Status.UNAUTHORIZED
+        server.nextResponseBody = """{"status":401,"message":"Unauthorized"}"""
+
+        val result = client.getAnnouncements(1)
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is NightscoutAuthException)
+    }
+
+    @Test
+    fun getAnnouncements_returnsFailureOnMalformedPayload() = runBlocking {
+        server.nextResponseBody = """[{"_id":"ann-1","message":"oops"""
+
+        val result = client.getAnnouncements(1)
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull()?.message?.contains("Malformed announcements response payload") == true)
+    }
+
+    @Test
+    fun getAnnouncementsSince_includesSinceMarkersInRequest() = runBlocking {
+        server.nextResponseBody = "[]"
+
+        val result = client.getAnnouncementsSince(1710500000000, "abc 123", 20)
+
+        assertTrue(result.isSuccess)
+        assertEquals(
+            "/api/v1/treatments?find[eventType]=Announcement&count=20&find[created_at][\$gte]=1710500000000&find[_id][\$gt]=abc+123",
+            server.capturedRequests[0].path
+        )
+        assertTrue(result.getOrNull()!!.isEmpty())
     }
 
     // --- Error Handling ---


### PR DESCRIPTION
### Motivation

- Add support for Nightscout "Announcement" treatment entries so the client can fetch and interpret announcement payloads. 
- Improve HTTP response handling and surface authentication errors distinctly for clearer upstream handling.

### Description

- Introduce `NightscoutAnnouncement` model and `NightscoutAnnouncementEndpoint` to build announcement-specific endpoints. 
- Add `NightscoutAnnouncementParser` and integrate it into `NightscoutClient` with new methods `getAnnouncements` and `getAnnouncementsSince`. 
- Improve HTTP handling in `NightscoutClient` by centralizing response reading with `readResponseBody` and mapping 401/403 into a new `NightscoutAuthException` via `createHttpException`. 
- Update `NightscoutApi` interface, add `NightscoutAuthException`, adjust the mock API, and add integration tests covering parsing, auth failure, malformed payloads, and since-marker behavior. 

### Testing

- Ran `NightscoutClientIntegrationTest` including `getAnnouncements_parsesResponse`, `getAnnouncements_returnsAuthFailureOnUnauthorized`, `getAnnouncements_returnsFailureOnMalformedPayload`, and `getAnnouncementsSince_includesSinceMarkersInRequest`, and they passed. 
- Ran `NightscoutSyncCoordinatorTest` android tests that reference the announcement model and the mock API changes, and they passed. 
- Existing Nightscout client upload/get tests were executed and continued to pass after the refactor to shared response handling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8e95387ec832c96715b2ef8362a4d)