### PR TITLE
Add percent/units temp basal entry mode and keyboard-driven submit

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/TempRateWindow.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/TempRateWindow.kt
@@ -2,10 +2,9 @@
 
 package com.jwoglom.controlx2.presentation.screens.sections
 
-import android.os.Handler
-import android.os.Looper
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -20,6 +19,8 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -32,30 +33,33 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.foundation.text.KeyboardActions
 import com.jwoglom.controlx2.LocalDataStore
 import com.jwoglom.controlx2.R
 import com.jwoglom.controlx2.presentation.DataStore
 import com.jwoglom.controlx2.presentation.components.HeaderLine
 import com.jwoglom.controlx2.presentation.navigation.TempRateInputPrefill
 import com.jwoglom.controlx2.presentation.screens.TempRatePreview
+import com.jwoglom.controlx2.presentation.screens.sections.components.DecimalOutlinedText
 import com.jwoglom.controlx2.presentation.screens.sections.components.IntegerOutlinedText
 import com.jwoglom.controlx2.presentation.util.LifecycleStateObserver
-import com.jwoglom.controlx2.shared.enums.BasalStatus
 import com.jwoglom.controlx2.shared.util.SendType
 import com.jwoglom.pumpx2.pump.messages.Message
 import com.jwoglom.pumpx2.pump.messages.request.control.SetTempRateRequest
-import com.jwoglom.pumpx2.pump.messages.request.currentStatus.HomeScreenMirrorRequest
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.TempRateRequest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.delay
 import timber.log.Timber
+import kotlin.math.roundToInt
 
 @Composable
 fun TempRateWindow(
@@ -64,8 +68,6 @@ fun TempRateWindow(
     onPrefillConsumed: () -> Unit = {},
     closeWindow: () -> Unit,
 ) {
-    val mainHandler = Handler(Looper.getMainLooper())
-    val context = LocalContext.current
     val dataStore = LocalDataStore.current
 
     val refreshScope = rememberCoroutineScope()
@@ -75,18 +77,28 @@ fun TempRateWindow(
     val percentRawValue = dataStore.tempRatePercentRawValue.observeAsState()
     val hoursRawValue = dataStore.tempRateHoursRawValue.observeAsState()
     val minutesRawValue = dataStore.tempRateMinutesRawValue.observeAsState()
+    val currentBasalRateRaw = dataStore.basalRate.observeAsState()
+
+    val focusManager = LocalFocusManager.current
+    val durationHoursFocusRequester = remember { FocusRequester() }
+    val durationMinutesFocusRequester = remember { FocusRequester() }
 
     var percentSubtitle by remember { mutableStateOf<String>("percent") }
     var hoursSubtitle by remember { mutableStateOf<String>("hours") }
     var minutesSubtitle by remember { mutableStateOf<String>("mins") }
 
+    var inputMode by remember { mutableStateOf(TempRateInputMode.PERCENT) }
     var percentHumanEntered by remember { mutableStateOf<Int?>(null) }
-    var percentHumanFocus by remember { mutableStateOf(false) }
+    var unitsRawValue by remember { mutableStateOf<String?>(null) }
+    var unitsHumanEntered by remember { mutableStateOf<Double?>(null) }
     var hoursHumanEntered by remember { mutableStateOf<Int?>(null) }
     var minutesHumanEntered by remember { mutableStateOf<Int?>(null) }
 
     var tempRateButtonEnabled by remember { mutableStateOf(false) }
     var tempRate by remember { mutableStateOf<SetTempRateRequest?>(null) }
+    var tempRateError by remember { mutableStateOf<String?>(null) }
+    var effectiveBasalPreview by remember { mutableStateOf<String?>(null) }
+    var effectivePercentPreview by remember { mutableStateOf<String?>(null) }
     var pendingPrefill by remember(prefill) { mutableStateOf(prefill) }
 
     var showPermissionCheckDialog by remember { mutableStateOf(false) }
@@ -166,75 +178,182 @@ fun TempRateWindow(
         percentHumanEntered = if (percentRawValue.value != null) rawToInt(percentRawValue.value) else null
         hoursHumanEntered = if (hoursRawValue.value != null) rawToInt(hoursRawValue.value) else null
         minutesHumanEntered = if (minutesRawValue.value != null) rawToInt(minutesRawValue.value) else null
+        unitsHumanEntered = if (unitsRawValue != null) unitsRawValue?.toDoubleOrNull() else null
     }
 
-    fun validTempRate(rawPercent: Int?, rawHours: Int?, rawMinutes: Int?): SetTempRateRequest? {
-        if (rawPercent == null || rawPercent < 0 || rawPercent > 250) {
-            return null
+    fun parseCurrentBasalRate(): Double? {
+        val raw = currentBasalRateRaw.value ?: return null
+        val numeric = raw.filter { it.isDigit() || it == '.' }
+        return numeric.toDoubleOrNull()
+    }
+
+    fun buildTempRateValidationResult(
+        mode: TempRateInputMode,
+        rawPercent: Int?,
+        rawUnits: Double?,
+        rawHours: Int?,
+        rawMinutes: Int?,
+        currentBasalRate: Double?
+    ): TempRateValidationResult {
+        val derivedPercent = when (mode) {
+            TempRateInputMode.PERCENT -> rawPercent
+            TempRateInputMode.UNITS -> {
+                if (rawUnits == null) {
+                    null
+                } else if (currentBasalRate == null || currentBasalRate <= 0.0) {
+                    return TempRateValidationResult(error = "Current profile basal rate is unavailable.")
+                } else {
+                    ((rawUnits / currentBasalRate) * 100.0).roundToInt()
+                }
+            }
         }
 
+        if (mode == TempRateInputMode.PERCENT) {
+            if (rawPercent == null) {
+                return TempRateValidationResult(error = "Enter a temp basal percent.")
+            }
+            if (rawPercent < 0 || rawPercent > 250) {
+                return TempRateValidationResult(error = "Percent must be between 0 and 250.")
+            }
+        }
+
+        if (mode == TempRateInputMode.UNITS) {
+            if (rawUnits == null) {
+                return TempRateValidationResult(error = "Enter a temp basal rate in U/hr.")
+            }
+            if (rawUnits < 0.0) {
+                return TempRateValidationResult(error = "Temp basal units must be 0 or greater.")
+            }
+            if (rawUnits != 0.0 && rawUnits < 0.05) {
+                return TempRateValidationResult(error = "Temp basal units must be 0 or at least 0.05 U/hr.")
+            }
+            if (derivedPercent == null || derivedPercent > 250) {
+                return TempRateValidationResult(error = "Effective percent cannot exceed 250%.")
+            }
+        }
+
+        val hours = rawHours ?: 0
+        val minutes = rawMinutes ?: 0
         if (rawHours == null && rawMinutes == null) {
-            return null
+            return TempRateValidationResult(error = "Enter a temp basal duration.")
+        }
+        if (hours < 0 || hours > 72 || minutes < 0 || minutes >= 60) {
+            return TempRateValidationResult(error = "Duration must be 0-72h and 0-59m.")
         }
 
-        var hours = 0
-        var minutes = 0
-        if (rawHours != null && rawMinutes != null) {
-            hours = rawHours
-            minutes = rawMinutes
-        } else if (rawHours == null && rawMinutes != null) {
-            hours = 0
-            minutes = rawMinutes
-        } else if (rawHours != null && rawMinutes == null) {
-            hours = rawHours
-            minutes = 0
-        } else {
-            return null
+        val totalMinutes = (60 * hours) + minutes
+        if (totalMinutes < 15) {
+            return TempRateValidationResult(error = "Duration must be at least 15 minutes.")
+        }
+        if (totalMinutes > 72 * 60) {
+            return TempRateValidationResult(error = "Duration cannot exceed 72 hours.")
         }
 
-        if (hours < 0 || hours > 72 || minutes < 15 || minutes >= 60) {
-            return null
+        if (derivedPercent == null || derivedPercent < 0 || derivedPercent > 250) {
+            return TempRateValidationResult(error = "Effective percent must be between 0 and 250.")
         }
 
-        if (60*hours + minutes > 72*60) {
-            return null
-        }
-
-        try {
-            return SetTempRateRequest(
-                60 * hours + minutes,
-                rawPercent
-
+        return try {
+            TempRateValidationResult(
+                request = SetTempRateRequest(totalMinutes, derivedPercent),
+                effectivePercent = derivedPercent.toDouble(),
+                effectiveBasalRate = currentBasalRate?.times(derivedPercent / 100.0)
             )
         } catch (e: IllegalArgumentException) {
-            return null
+            TempRateValidationResult(error = "Invalid temp basal request.")
         }
     }
 
-    LaunchedEffect (percentRawValue.value, hoursRawValue.value, minutesRawValue.value) {
+    fun submitIfValid() {
+        val result = buildTempRateValidationResult(
+            mode = inputMode,
+            rawPercent = percentHumanEntered,
+            rawUnits = unitsHumanEntered,
+            rawHours = hoursHumanEntered,
+            rawMinutes = minutesHumanEntered,
+            currentBasalRate = parseCurrentBasalRate()
+        )
+        tempRateError = result.error
+        tempRate = result.request
+        if (result.request != null) {
+            showPermissionCheckDialog = true
+            focusManager.clearFocus()
+        }
+    }
+
+    LaunchedEffect (percentRawValue.value, unitsRawValue, hoursRawValue.value, minutesRawValue.value, inputMode, currentBasalRateRaw.value) {
         recalculate()
-        val request = validTempRate(percentHumanEntered, hoursHumanEntered, minutesHumanEntered)
-        tempRateButtonEnabled = request != null
+        val result = buildTempRateValidationResult(
+            mode = inputMode,
+            rawPercent = percentHumanEntered,
+            rawUnits = unitsHumanEntered,
+            rawHours = hoursHumanEntered,
+            rawMinutes = minutesHumanEntered,
+            currentBasalRate = parseCurrentBasalRate()
+        )
+        tempRateButtonEnabled = result.request != null
+        tempRateError = result.error
+        effectiveBasalPreview = result.effectiveBasalRate?.let { "Effective basal rate: ${"%.2f".format(it)} U/hr" }
+        effectivePercentPreview = result.effectivePercent?.let { "Effective percent: ${"%.0f".format(it)}%" }
     }
 
     HeaderLine("Temp Rate")
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        horizontalArrangement = Arrangement.Center
+    ) {
+        FilterChip(
+            selected = inputMode == TempRateInputMode.PERCENT,
+            onClick = { inputMode = TempRateInputMode.PERCENT },
+            label = { Text("Percent") },
+            modifier = Modifier.padding(end = 8.dp)
+        )
+        FilterChip(
+            selected = inputMode == TempRateInputMode.UNITS,
+            onClick = { inputMode = TempRateInputMode.UNITS },
+            label = { Text("Units (U/hr)") }
+        )
+    }
 
     Row(
         modifier = Modifier.fillMaxWidth()
     ) {
         Column(Modifier.weight(0.75f)) {}
         Column(Modifier.weight(1f)) {
-            IntegerOutlinedText(
-                title = percentSubtitle,
-                value = percentRawValue.value,
-                onValueChange = {
-                    dataStore.tempRatePercentRawValue.value = it
-                    percentHumanEntered = if (it == "") null else it.toIntOrNull()
-                },
-                modifier = Modifier.onFocusChanged {
-                    percentHumanFocus = it.isFocused
-                }
-            )
+            if (inputMode == TempRateInputMode.PERCENT) {
+                IntegerOutlinedText(
+                    title = percentSubtitle,
+                    value = percentRawValue.value,
+                    onValueChange = {
+                        dataStore.tempRatePercentRawValue.value = it
+                        percentHumanEntered = if (it == "") null else it.toIntOrNull()
+                    },
+                    imeAction = ImeAction.Next,
+                    keyboardActions = KeyboardActions(
+                        onNext = {
+                            durationHoursFocusRequester.requestFocus()
+                        }
+                    )
+                )
+            } else {
+                DecimalOutlinedText(
+                    title = "U/hr",
+                    value = unitsRawValue,
+                    onValueChange = {
+                        unitsRawValue = it
+                        unitsHumanEntered = if (it == "") null else it.toDoubleOrNull()
+                    },
+                    imeAction = ImeAction.Next,
+                    keyboardActions = KeyboardActions(
+                        onNext = {
+                            durationHoursFocusRequester.requestFocus()
+                        }
+                    )
+                )
+            }
         }
         Column(Modifier.weight(0.75f)) {}
     }
@@ -250,7 +369,14 @@ fun TempRateWindow(
             IntegerOutlinedText(
                 title = hoursSubtitle,
                 value = hoursRawValue.value,
-                onValueChange = { dataStore.tempRateHoursRawValue.value = it }
+                onValueChange = { dataStore.tempRateHoursRawValue.value = it },
+                imeAction = ImeAction.Next,
+                keyboardActions = KeyboardActions(
+                    onNext = {
+                        durationMinutesFocusRequester.requestFocus()
+                    }
+                ),
+                modifier = Modifier.focusRequester(durationHoursFocusRequester)
             )
         }
 
@@ -264,10 +390,42 @@ fun TempRateWindow(
                 onValueChange = {
                     dataStore.tempRateMinutesRawValue.value = it
                     minutesHumanEntered = if (it == "") null else it.toIntOrNull()
-                }
+                },
+                imeAction = ImeAction.Done,
+                keyboardActions = KeyboardActions(
+                    onDone = {
+                        submitIfValid()
+                    }
+                ),
+                modifier = Modifier.focusRequester(durationMinutesFocusRequester)
             )
         }
         Column(Modifier.weight(0.5f)) {}
+    }
+
+    tempRateError?.let {
+        Text(
+            text = it,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.error,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 8.dp)
+        )
+    }
+
+    val modePreviewText = when (inputMode) {
+        TempRateInputMode.PERCENT -> effectiveBasalPreview
+        TempRateInputMode.UNITS -> effectivePercentPreview
+    }
+    modePreviewText?.let {
+        Text(
+            text = it,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+        )
     }
 
 
@@ -283,10 +441,7 @@ fun TempRateWindow(
 
             Button(
                 onClick = {
-                    tempRate = validTempRate(percentHumanEntered, hoursHumanEntered, minutesHumanEntered)
-                    if (tempRate != null) {
-                        showPermissionCheckDialog = true
-                    }
+                    submitIfValid()
                 },
                 contentPadding = ButtonDefaults.ButtonWithIconContentPadding,
                 enabled = tempRateButtonEnabled,
@@ -386,6 +541,18 @@ fun resetTempRateDataStoreState(dataStore: DataStore) {
     dataStore.tempRateHoursRawValue.value = null
     dataStore.tempRateMinutesRawValue.value = null
 }
+
+private enum class TempRateInputMode {
+    PERCENT,
+    UNITS
+}
+
+private data class TempRateValidationResult(
+    val request: SetTempRateRequest? = null,
+    val error: String? = null,
+    val effectiveBasalRate: Double? = null,
+    val effectivePercent: Double? = null
+)
 
 @Preview
 @Composable

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/DecimalOutlinedText.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/DecimalOutlinedText.kt
@@ -29,6 +29,8 @@ fun DecimalOutlinedText(
     value: String?,
     onValueChange: (String) -> Unit,
     onSubmitRequested: (() -> Unit)? = null,
+    imeAction: ImeAction = ImeAction.Done,
+    keyboardActions: KeyboardActions? = null,
     modifier: Modifier = Modifier
 ) {
     var error = false
@@ -75,9 +77,9 @@ fun DecimalOutlinedText(
             autoCorrect = false,
             capitalization = KeyboardCapitalization.None,
             keyboardType = KeyboardType.Number,
-            imeAction = ImeAction.Done,
+            imeAction = imeAction,
         ),
-        keyboardActions = KeyboardActions(
+        keyboardActions = keyboardActions ?: KeyboardActions(
             onDone = {
                 onSubmitRequested?.invoke()
             }

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/IntegerOutlinedText.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/IntegerOutlinedText.kt
@@ -21,6 +21,8 @@ fun IntegerOutlinedText(
     value: String?,
     onValueChange: (String) -> Unit,
     onSubmitRequested: (() -> Unit)? = null,
+    imeAction: ImeAction = ImeAction.Done,
+    keyboardActions: KeyboardActions? = null,
     modifier: Modifier = Modifier
 ) {
     var error = false
@@ -39,9 +41,9 @@ fun IntegerOutlinedText(
             autoCorrect = false,
             capitalization = KeyboardCapitalization.None,
             keyboardType = KeyboardType.Number,
-            imeAction = ImeAction.Done,
+            imeAction = imeAction,
         ),
-        keyboardActions = KeyboardActions(
+        keyboardActions = keyboardActions ?: KeyboardActions(
             onDone = {
                 onSubmitRequested?.invoke()
             }


### PR DESCRIPTION
### Motivation
- Improve temp basal entry ergonomics by enabling keyboard `Enter/Next/Done` navigation so users can complete the flow without tapping between fields.
- Provide both percent-based and units-based entry modes so users can choose to enter a percent or an explicit U/hr value.
- Surface computed effective values and robust validation so users see the resulting U/hr or percent and are protected from invalid/unsafe inputs (e.g. >250% or <0.05 U/hr except 0).

### Description
- Added a two-mode selector to `TempRateWindow` (Compose `FilterChip` toggle) to switch between `PERCENT` and `UNITS (U/hr)` entry and unified submission/validation logic in `TempRateWindow`. 
- Implemented units-mode → effective percent conversion (using current profile basal from `DataStore.basalRate`) and computed preview text so percent mode shows effective `U/hr` and units mode shows effective `%`.
- Added comprehensive validation rules (min duration 15 minutes, max 72 hours, effective percent between 0–250, units must be 0 or >=0.05 U/hr) and inline error display; validation drives button enablement and submission.
- Improved IME/keyboard flow using `FocusRequester` and configurable `ImeAction`/`KeyboardActions` so the top field uses `Next` to focus hours, hours uses `Next` to focus minutes, and minutes uses `Done` to submit when inputs are valid.
- Extended shared inputs `IntegerOutlinedText` and `DecimalOutlinedText` to accept `imeAction` and `keyboardActions` parameters so callers control keyboard navigation/submit behavior.

### Testing
- Ran `./gradlew :mobile:compileDebugKotlin --console=plain` and the build completed successfully (Kotlin compile with standard warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc0e522710832ca238f90f2bad3ddf)