### PR TITLE
Require xDrip reload only when sync enablement changes

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/XdripSettings.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/XdripSettings.kt
@@ -53,14 +53,17 @@ fun XdripSettings(
     var config by remember { mutableStateOf(XdripSyncConfig.load(prefs)) }
 
     fun saveConfig(newConfig: XdripSyncConfig, showToastText: String? = null) {
+        val oldConfig = config
         config = newConfig
         XdripSyncConfig.save(prefs, newConfig)
 
-        coroutineScope.launch {
-            delay(250)
-            sendMessage("/to-phone/force-reload", "".toByteArray())
-            delay(250)
-            sendMessage("/to-phone/app-reload", "".toByteArray())
+        if (newConfig.requiresReloadComparedTo(oldConfig)) {
+            coroutineScope.launch {
+                delay(250)
+                sendMessage("/to-phone/force-reload", "".toByteArray())
+                delay(250)
+                sendMessage("/to-phone/app-reload", "".toByteArray())
+            }
         }
 
         if (showToastText != null) {

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/xdrip/XdripSyncConfig.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/xdrip/XdripSyncConfig.kt
@@ -105,4 +105,15 @@ data class XdripSyncConfig(
     fun enabledPayloads(): Set<XdripPayloadGroup> {
         return XdripPayloadGroup.all().filterTo(mutableSetOf()) { isPayloadEnabled(it) }
     }
+
+    /**
+     * Returns whether changing from [oldConfig] to this config requires app/service reload.
+     *
+     * xDrip payload toggles and minimum-interval fields are consumed at runtime, so they do not
+     * require restart. We only reload when global xDrip sync is toggled on/off so lifecycle setup
+     * can be re-initialized deterministically.
+     */
+    fun requiresReloadComparedTo(oldConfig: XdripSyncConfig): Boolean {
+        return oldConfig.enabled != enabled
+    }
 }

--- a/mobile/src/test/java/com/jwoglom/controlx2/sync/xdrip/XdripMessageDispatcherTest.kt
+++ b/mobile/src/test/java/com/jwoglom/controlx2/sync/xdrip/XdripMessageDispatcherTest.kt
@@ -166,4 +166,24 @@ class XdripMessageDispatcherTest {
         assertTrue(broadcaster.statuslinePayloads.isEmpty())
         assertTrue(broadcaster.treatmentPayloads.isEmpty())
     }
+
+    @Test
+    fun onEvent_readsLatestConfigProviderValuesWithoutRestart() {
+        val broadcaster = FakeBroadcaster()
+        var config = XdripSyncConfig(enabled = true, sendCgmSgv = false)
+        val dispatcher = XdripMessageDispatcher(
+            broadcaster = broadcaster,
+            configProvider = { config },
+            nowProvider = { Instant.parse("2026-01-01T00:00:00Z") }
+        )
+
+        dispatcher.onEvent(DispatchEvent.CgmSgv(120))
+        assertTrue(broadcaster.sgvPayloads.isEmpty())
+
+        config = config.copy(sendCgmSgv = true, cgmSgvMinimumIntervalSeconds = 15)
+        dispatcher.onEvent(DispatchEvent.CgmSgv(121))
+
+        assertEquals(1, broadcaster.sgvPayloads.size)
+        assertEquals(15, broadcaster.sgvPayloads.single().minimumIntervalSeconds)
+    }
 }

--- a/mobile/src/test/java/com/jwoglom/controlx2/sync/xdrip/XdripSyncConfigTest.kt
+++ b/mobile/src/test/java/com/jwoglom/controlx2/sync/xdrip/XdripSyncConfigTest.kt
@@ -1,0 +1,33 @@
+package com.jwoglom.controlx2.sync.xdrip
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class XdripSyncConfigTest {
+    @Test
+    fun requiresReloadComparedTo_payloadAndIntervalUpdatesDoNotRequireReload() {
+        val oldConfig = XdripSyncConfig(enabled = true)
+        val newConfig = oldConfig.copy(
+            sendCgmSgv = false,
+            sendPumpDeviceStatus = false,
+            sendTreatments = false,
+            sendStatusLine = false,
+            cgmSgvMinimumIntervalSeconds = 30,
+            pumpDeviceStatusMinimumIntervalSeconds = 45,
+            treatmentsMinimumIntervalSeconds = 60,
+            statusLineMinimumIntervalSeconds = 120
+        )
+
+        assertFalse(newConfig.requiresReloadComparedTo(oldConfig))
+    }
+
+    @Test
+    fun requiresReloadComparedTo_enabledToggleRequiresReload() {
+        val disabled = XdripSyncConfig(enabled = false)
+        val enabled = disabled.copy(enabled = true)
+
+        assertTrue(enabled.requiresReloadComparedTo(disabled))
+        assertTrue(disabled.requiresReloadComparedTo(enabled))
+    }
+}


### PR DESCRIPTION
### Motivation
- Changing xDrip payload flags or interval settings previously triggered an unnecessary app/service reload. 
- Only toggling the global xDrip sync (`enabled`) should require lifecycle re-initialization so runtime consumers can update without restart.

### Description
- Updated `XdripSyncConfig.requiresReloadComparedTo` to return `true` only when `enabled` changes between the old and new config and added clarifying documentation. 
- Added unit coverage in `XdripSyncConfigTest` to assert payload/interval changes do not require reload and that ON↔OFF transitions do. 
- No other behavior changes; runtime-consumed fields remain reload-free so dispatchers can pick up updates dynamically.

### Testing
- Ran unit tests with `./gradlew :mobile:testDebugUnitTest --tests "com.jwoglom.controlx2.sync.xdrip.XdripSyncConfigTest" --tests "com.jwoglom.controlx2.sync.xdrip.XdripMessageDispatcherTest"` and the build completed successfully. 
- The new/updated tests passed and verify both the non-reload and reload-on-enabled-toggle behaviors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bce5a80b18832c8604d600e0684ff0)