### PR TITLE
Use API-version-aware LastBolusStatus requests in bolus cancel dialogs

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/bolus/BolusDialogs.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/bolus/BolusDialogs.kt
@@ -31,11 +31,14 @@ import com.jwoglom.controlx2.shared.util.SendType
 import com.jwoglom.controlx2.shared.util.snakeCaseToSpace
 import com.jwoglom.controlx2.shared.util.twoDecimalPlaces
 import com.jwoglom.controlx2.shared.util.twoDecimalPlaces1000Unit
+import com.jwoglom.pumpx2.pump.PumpState
 import com.jwoglom.pumpx2.pump.messages.Message
+import com.jwoglom.pumpx2.pump.messages.builders.LastBolusStatusRequestBuilder
 import com.jwoglom.pumpx2.pump.messages.calculator.BolusCalcUnits
 import com.jwoglom.pumpx2.pump.messages.calculator.BolusParameters
+import com.jwoglom.pumpx2.pump.messages.models.ApiVersion
+import com.jwoglom.pumpx2.pump.messages.models.KnownApiVersion
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.CurrentBolusStatusRequest
-import com.jwoglom.pumpx2.pump.messages.request.currentStatus.LastBolusStatusV2Request
 import com.jwoglom.pumpx2.pump.messages.response.control.CancelBolusResponse
 import com.jwoglom.pumpx2.pump.messages.response.currentStatus.BolusCalcDataSnapshotResponse
 import com.jwoglom.pumpx2.pump.messages.response.currentStatus.CurrentBolusStatusResponse
@@ -400,11 +403,14 @@ fun CancelledDialogRegion(
     val bolusInitiateResponse = dataStore.bolusInitiateResponse.observeAsState()
     val lastBolusStatusResponse = dataStore.lastBolusStatusResponse.observeAsState()
 
+    fun apiVersion(): ApiVersion = PumpState.getPumpAPIVersion() ?: KnownApiVersion.API_V2_5.get()
+    fun lastBolusStatusRequest(): Message = LastBolusStatusRequestBuilder.create(apiVersion())
+
     LaunchedEffect (bolusCancelResponse.value, Unit) {
         Timber.d("showCancelledDialog querying LastBolusStatus")
-        sendPumpCommands(SendType.STANDARD, listOf(LastBolusStatusV2Request()))
+        sendPumpCommands(SendType.STANDARD, listOf(lastBolusStatusRequest()))
         mainHandler.postDelayed({
-            sendPumpCommands(SendType.STANDARD, listOf(LastBolusStatusV2Request()))
+            sendPumpCommands(SendType.STANDARD, listOf(lastBolusStatusRequest()))
         }, 500)
     }
 
@@ -424,7 +430,7 @@ fun CancelledDialogRegion(
                 Timber.d("showCancelledDialog lastBolusStatus postDelayed")
                 sendPumpCommands(
                     SendType.STANDARD,
-                    listOf(LastBolusStatusV2Request())
+                    listOf(lastBolusStatusRequest())
                 )
             }, 500)
         }

--- a/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/components/bolus/BolusCancelledPhase.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/components/bolus/BolusCancelledPhase.kt
@@ -22,8 +22,11 @@ import com.jwoglom.controlx2.presentation.DataStore
 import com.jwoglom.controlx2.shared.util.SendType
 import com.jwoglom.controlx2.shared.util.snakeCaseToSpace
 import com.jwoglom.controlx2.shared.util.twoDecimalPlaces1000Unit
+import com.jwoglom.pumpx2.pump.PumpState
 import com.jwoglom.pumpx2.pump.messages.Message
-import com.jwoglom.pumpx2.pump.messages.request.currentStatus.LastBolusStatusV2Request
+import com.jwoglom.pumpx2.pump.messages.builders.LastBolusStatusRequestBuilder
+import com.jwoglom.pumpx2.pump.messages.models.ApiVersion
+import com.jwoglom.pumpx2.pump.messages.models.KnownApiVersion
 import com.jwoglom.pumpx2.pump.messages.response.control.CancelBolusResponse.CancelStatus
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
@@ -38,6 +41,9 @@ fun BolusCancelledPhase(
     refreshScope: CoroutineScope,
     sendPumpCommands: (SendType, List<Message>) -> Unit,
 ) {
+    fun apiVersion(): ApiVersion = PumpState.getPumpAPIVersion() ?: KnownApiVersion.API_V2_5.get()
+    fun lastBolusStatusRequest(): Message = LastBolusStatusRequestBuilder.create(apiVersion())
+
     val scrollState = rememberScalingLazyListState()
     Dialog(showDialog = showCancelledDialog, onDismissRequest = onDismiss, scrollState = scrollState) {
         val bolusCancelResponse = dataStore.bolusCancelResponse.observeAsState()
@@ -45,7 +51,7 @@ fun BolusCancelledPhase(
         val lastBolusStatusResponse = dataStore.lastBolusStatusResponse.observeAsState()
 
         LaunchedEffect(bolusCancelResponse.value, Unit) {
-            sendPumpCommands(SendType.STANDARD, listOf(LastBolusStatusV2Request()))
+            sendPumpCommands(SendType.STANDARD, listOf(lastBolusStatusRequest()))
         }
 
         fun matchesBolusId(): Boolean? {
@@ -61,7 +67,7 @@ fun BolusCancelledPhase(
             if (matchesBolusId() == false) {
                 refreshScope.launch {
                     delay(250)
-                    sendPumpCommands(SendType.STANDARD, listOf(LastBolusStatusV2Request()))
+                    sendPumpCommands(SendType.STANDARD, listOf(lastBolusStatusRequest()))
                 }
             }
         }


### PR DESCRIPTION
### Motivation
- The bolus-cancel flows were hardcoded to `LastBolusStatusV2Request()`, which prevents selecting the appropriate request for pumps running different API versions.
- Use the PumpX2 request builder to create the correct `LastBolusStatus` request based on the pump API version so cancel dialogs query the pump correctly across versions.

### Description
- Replaced direct `LastBolusStatusV2Request()` usage with `LastBolusStatusRequestBuilder.create(apiVersion())` in mobile cancel dialog (`CancelledDialogRegion`) and wear cancel phase (`BolusCancelledPhase`).
- Added local `apiVersion()` helpers that call `PumpState.getPumpAPIVersion()` with a `KnownApiVersion.API_V2_5` fallback, and a `lastBolusStatusRequest()` helper wrapping the builder call.
- Updated imports to include `PumpState`, `LastBolusStatusRequestBuilder`, `ApiVersion`, and `KnownApiVersion`, and removed the hardcoded V2 request imports where applicable.

### Testing
- Compiled Kotlin for both modules with `./gradlew :mobile:compileDebugKotlin :wear:compileDebugKotlin --console=plain`, which completed successfully (BUILD SUCCESSFUL).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c097b65388832c90bef18c96c9f3d4)