### PR TITLE
Disable sleep/exercise mode and temp basal on non-Mobi pumps

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Actions.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Actions.kt
@@ -371,6 +371,7 @@ fun Actions(
 
                 item {
                     val controlIQMode = ds.controlIQMode.observeAsState()
+                    val isMobi = determinePumpModel(deviceName.value ?: "") == KnownDeviceModel.MOBI
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
@@ -392,6 +393,7 @@ fun Actions(
                             trailingContent = {
                                 Switch(
                                     checked = controlIQMode.value == UserMode.EXERCISE,
+                                    enabled = isMobi,
                                     onCheckedChange = { checked ->
                                         if (checked) {
                                             // User toggling to ON
@@ -451,6 +453,7 @@ fun Actions(
 
                 item {
                     val controlIQMode = ds.controlIQMode.observeAsState()
+                    val isMobi = determinePumpModel(deviceName.value ?: "") == KnownDeviceModel.MOBI
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
@@ -472,6 +475,7 @@ fun Actions(
                             trailingContent = {
                                 Switch(
                                     checked = controlIQMode.value == UserMode.SLEEP,
+                                    enabled = isMobi,
                                     onCheckedChange = { checked ->
                                         if (checked) {
                                             // User toggling to ON
@@ -530,6 +534,7 @@ fun Actions(
                 item {
                     val tempRateActive = ds.tempRateActive.observeAsState()
                     val tempRateDetails = ds.tempRateDetails.observeAsState()
+                    val isMobi = determinePumpModel(deviceName.value ?: "") == KnownDeviceModel.MOBI
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
@@ -561,7 +566,7 @@ fun Actions(
                                     contentDescription = null,
                                 )
                             },
-                            modifier = Modifier.clickable {
+                            modifier = Modifier.clickable(enabled = isMobi) {
                                 when (tempRateActive.value) {
                                     true -> { showStopTempRateMenu = true }
                                     false -> { openTempRateWindow() }


### PR DESCRIPTION
## Summary
- Disable exercise mode and sleep mode Switch toggles on non-Mobi pumps via `enabled = isMobi`
- Disable temp basal ListItem click handler on non-Mobi pumps via `clickable(enabled = isMobi)`
- Follows existing codebase pattern of per-item `determinePumpModel()` checks used in Actions.kt and other screen sections

## Test plan
- [ ] Connect to a non-Mobi pump (t:slim X2) and verify exercise/sleep toggles are grayed out and non-interactive
- [ ] Connect to a non-Mobi pump and verify temp rate item is not clickable
- [ ] Connect to a Mobi pump and verify all three controls remain fully functional

https://claude.ai/code/session_01VDx4ms64KyjYbseepYKqWy