### PR TITLE
Fix ActiveAamBitsRequest crash on t:slim X2 pumps

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/CartridgeActions.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/CartridgeActions.kt
@@ -52,6 +52,9 @@ import com.jwoglom.controlx2.shared.enums.BasalStatus
 import com.jwoglom.controlx2.shared.presentation.intervalOf
 import com.jwoglom.controlx2.shared.util.SendType
 import com.jwoglom.pumpx2.pump.messages.Message
+import com.jwoglom.pumpx2.pump.PumpState
+import com.jwoglom.pumpx2.pump.messages.models.ApiVersion
+import com.jwoglom.pumpx2.pump.messages.models.KnownApiVersion
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.CGMStatusRequest
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.HomeScreenMirrorRequest
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.TimeSinceResetRequest
@@ -370,11 +373,19 @@ val cartridgeActionsCommands = listOf(
     LoadStatusRequest()
 )
 
+fun cartridgeApiVersion(): ApiVersion {
+    var apiVersion = PumpState.getPumpAPIVersion()
+    if (apiVersion == null) {
+        apiVersion = KnownApiVersion.API_V2_5.get()
+    }
+    return apiVersion
+}
+
 val cartridgeNotificationCommands = listOf(
     HomeScreenMirrorRequest(),
     *NotificationBundle.allRequests().toTypedArray(),
 ).filter { msg ->
-    apiVersion() >= msg.props().minApi.get()
+    !msg.props().minApi.get().greaterThan(cartridgeApiVersion())
 }
 
 val cartridgeActionsFields = listOf(

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Dashboard.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Dashboard.kt
@@ -276,7 +276,7 @@ val dashboardCommands = listOf(
     // update notification badge
     *NotificationBundle.allRequests().toTypedArray()
 ).filter { msg ->
-    apiVersion() >= msg.props().minApi.get()
+    !msg.props().minApi.get().greaterThan(apiVersion())
 }
 
 val dashboardFields = listOf(

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Notifications.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Notifications.kt
@@ -57,6 +57,9 @@ import com.jwoglom.controlx2.shared.presentation.intervalOf
 import com.jwoglom.controlx2.shared.util.SendType
 import com.jwoglom.controlx2.util.determinePumpModel
 import com.jwoglom.pumpx2.pump.messages.Message
+import com.jwoglom.pumpx2.pump.PumpState
+import com.jwoglom.pumpx2.pump.messages.models.ApiVersion
+import com.jwoglom.pumpx2.pump.messages.models.KnownApiVersion
 import com.jwoglom.pumpx2.pump.messages.models.KnownDeviceModel
 import com.jwoglom.pumpx2.pump.messages.models.NotificationBundle
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.HomeScreenMirrorRequest
@@ -203,11 +206,19 @@ fun Notifications(
     }
 }
 
+fun notificationsApiVersion(): ApiVersion {
+    var apiVersion = PumpState.getPumpAPIVersion()
+    if (apiVersion == null) {
+        apiVersion = KnownApiVersion.API_V2_5.get()
+    }
+    return apiVersion
+}
+
 val notificationsCommands = listOf(
     HomeScreenMirrorRequest(),
     *NotificationBundle.allRequests().toTypedArray()
 ).filter { msg ->
-    apiVersion() >= msg.props().minApi.get()
+    !msg.props().minApi.get().greaterThan(notificationsApiVersion())
 }
 
 val notificationsFields = listOf(


### PR DESCRIPTION
## Summary

- `ActiveAamBitsRequest` (opCode -110) requires API v3.5 (Tandem Mobi) but was unconditionally sent to all pumps via `NotificationBundle.allRequests()`
- On t:slim X2 (API v2.5), the pump responds with `ErrorResponse[UNDEFINED_ERROR]`, triggering `onPumpCriticalError` and disconnecting
- Added `.filter { apiVersion() >= msg.props().minApi.get() }` to all three command lists (`dashboardCommands`, `notificationsCommands`, `cartridgeNotificationCommands`) so messages requiring a higher API version than the connected pump are excluded at runtime

## Test plan

- [ ] Connect to a t:slim X2 (API v2.5) — dashboard should load without `onPumpCriticalError` or disconnection
- [ ] Verify `ActiveAamBitsRequest` is NOT sent to t:slim X2
- [ ] Connect to a Tandem Mobi (API v3.5) — verify `ActiveAamBitsRequest` IS still sent and notifications work normally
- [ ] Verify notification badge updates and cartridge actions still work on both pump models

https://claude.ai/code/session_019TVhsihuBGa91HzKKLwomy