### PR TITLE
Add debug preference to control qualifying event toasts (default off)

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/CommService.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/CommService.kt
@@ -349,7 +349,9 @@ class CommService : Service() {
                 events: MutableSet<QualifyingEvent>?
             ) {
                 Timber.i("onReceiveQualifyingEvent: $events")
-                Toast.makeText(this@CommService, "Events: $events", Toast.LENGTH_SHORT).show()
+                if (Prefs(this@CommService).qualifyingEventToastsEnabled()) {
+                    Toast.makeText(this@CommService, "Events: $events", Toast.LENGTH_SHORT).show()
+                }
                 if (events != null && QualifyingEvent.PUMP_COMMUNICATIONS_SUSPENDED in events) {
                     Timber.w("onReceiveQualifyingEvent: PUMP_COMMUNICATIONS_SUSPENDED — pausing sends")
                     currentSession?.pauseSends(currentSession?.rateLimitConfig?.commSuspendedPauseMs ?: 5_000)

--- a/mobile/src/main/java/com/jwoglom/controlx2/Prefs.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/Prefs.kt
@@ -177,6 +177,18 @@ class Prefs(val context: Context) {
         prefs().edit().putString("glucose-unit", unit?.name).commit()
     }
 
+
+    /**
+     * Whether to show qualifying event toasts from CommService.
+     */
+    fun qualifyingEventToastsEnabled(): Boolean {
+        return prefs().getBoolean("qualifying-event-toasts-enabled", false)
+    }
+
+    fun setQualifyingEventToastsEnabled(b: Boolean) {
+        prefs().edit().putBoolean("qualifying-event-toasts-enabled", b).commit()
+    }
+
     /**
      * Whether the HTTP Debug API is enabled
      */

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Debug.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Debug.kt
@@ -911,6 +911,29 @@ fun Debug(
             }
 
             item {
+                var qualifyingEventToastsEnabled by remember { mutableStateOf(Prefs(context).qualifyingEventToastsEnabled()) }
+                ListItem(
+                    headlineContent = { Text(if (qualifyingEventToastsEnabled) "Disable Qualifying Event Toasts" else "Enable Qualifying Event Toasts") },
+                    supportingContent = { Text("Show toast notifications when CommService receives qualifying events.") },
+                    leadingContent = {
+                        Icon(
+                            if (qualifyingEventToastsEnabled) Icons.Filled.Check else Icons.Filled.Close,
+                            contentDescription = null,
+                        )
+                    },
+                    modifier = Modifier.clickable {
+                        qualifyingEventToastsEnabled = !qualifyingEventToastsEnabled
+                        Prefs(context).setQualifyingEventToastsEnabled(qualifyingEventToastsEnabled)
+                        Toast.makeText(
+                            context,
+                            "Qualifying event toasts ${if (qualifyingEventToastsEnabled) "enabled" else "disabled"}",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                )
+            }
+
+            item {
                 var httpDebugApiEnabled by remember { mutableStateOf(Prefs(context).httpDebugApiEnabled()) }
                 ListItem(
                     headlineContent = { Text(if (httpDebugApiEnabled) "Disable HTTP Debug API" else "Enable HTTP Debug API") },


### PR DESCRIPTION
### Motivation
- Quiet down the service by making the qualifying-event toast opt-in so normal runs are not cluttered by transient toasts.
- Expose the toggle in the debug UI so developers/power users can enable the toasts when diagnosing issues.

### Description
- Added a new preference accessor `qualifyingEventToastsEnabled()` and setter `setQualifyingEventToastsEnabled()` to `Prefs` with a default of `false` (`mobile/src/main/java/com/jwoglom/controlx2/Prefs.kt`).
- Updated `CommService.onReceiveQualifyingEvent` to only call `Toast.makeText(...)` when `Prefs(...).qualifyingEventToastsEnabled()` returns `true` (`mobile/src/main/java/com/jwoglom/controlx2/CommService.kt`).
- Added a toggle entry to the Debug screen that flips the new pref at runtime and shows a confirmation toast (`mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Debug.kt`).

### Testing
- Bootstrapped the repo-local Android SDK with `./.codex/setup.sh` which completed successfully.
- Compiled the mobile Kotlin sources using `./gradlew :mobile:compileDebugKotlin --console=plain` which completed with `BUILD SUCCESSFUL` and no compilation errors.
- No additional automated unit/instrumentation tests were introduced or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7014bbf08832ca154e96ff677c524)