### PR TITLE
Extract PumpCommHandler from CommService inner class

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/CommService.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/CommService.kt
@@ -1,6 +1,5 @@
 package com.jwoglom.controlx2
 
-import android.Manifest
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -8,21 +7,15 @@ import android.app.PendingIntent
 import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.app.PendingIntent.FLAG_ONE_SHOT
 import android.app.Service
-import android.bluetooth.BluetoothAdapter
-import android.bluetooth.le.ScanResult
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.SharedPreferences
-import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
 import android.media.RingtoneManager
-import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
 import android.os.Looper
-import android.os.Message
 import android.os.Process
 import android.widget.Toast
 import androidx.core.app.NotificationCompat
@@ -32,88 +25,46 @@ import com.jwoglom.controlx2.db.historylog.HistoryLogItem
 import com.jwoglom.controlx2.db.historylog.HistoryLogRepo
 import com.jwoglom.controlx2.messaging.MessageBusFactory
 import com.jwoglom.controlx2.presentation.util.ShouldLogToFile
+import com.jwoglom.controlx2.pump.BleChangeReceiver
+import com.jwoglom.controlx2.pump.CommServiceCallbacks
+import com.jwoglom.controlx2.pump.PumpCommHandler
+import com.jwoglom.controlx2.pump.PumpCommState
+import com.jwoglom.controlx2.pump.PumpFinderCommHandler
 import com.jwoglom.controlx2.pump.PumpSession
 import com.jwoglom.controlx2.shared.CommServiceCodes
 import com.jwoglom.controlx2.shared.InitiateConfirmedBolusSerializer
 import com.jwoglom.controlx2.shared.PumpMessageSerializer
-import com.jwoglom.controlx2.shared.PumpQualifyingEventsSerializer
 import com.jwoglom.controlx2.shared.messaging.MessageBus
 import com.jwoglom.controlx2.shared.messaging.MessageBusSender
 import com.jwoglom.controlx2.shared.messaging.MessageListener
-import com.jwoglom.controlx2.shared.util.SendType
 import com.jwoglom.controlx2.shared.util.setupTimber
 import com.jwoglom.controlx2.shared.util.shortTime
 import com.jwoglom.controlx2.shared.util.twoDecimalPlaces
-import com.jwoglom.controlx2.sync.nightscout.NightscoutSyncWorker
-import com.jwoglom.controlx2.sync.xdrip.XdripMessageDispatcher
 import com.jwoglom.controlx2.util.AppVersionCheck
-import com.jwoglom.controlx2.util.DataClientState
-import com.jwoglom.controlx2.util.HistoryLogFetcher
-import com.jwoglom.controlx2.util.HistoryLogSyncWorker
-import com.jwoglom.controlx2.util.extractPumpSid
 import com.jwoglom.pumpx2.pump.PumpState
-import com.jwoglom.pumpx2.pump.TandemError
-import com.jwoglom.pumpx2.pump.bluetooth.PumpReadyState
-import com.jwoglom.pumpx2.pump.bluetooth.TandemBluetoothHandler
-import com.jwoglom.pumpx2.pump.bluetooth.TandemConfig
-import com.jwoglom.pumpx2.pump.bluetooth.TandemPump
-import com.jwoglom.pumpx2.pump.messages.Packetize
 import com.jwoglom.pumpx2.pump.messages.bluetooth.Characteristic
-import com.jwoglom.pumpx2.pump.messages.bluetooth.CharacteristicUUID
-import com.jwoglom.pumpx2.pump.messages.bluetooth.PumpStateSupplier
-import com.jwoglom.pumpx2.pump.messages.bluetooth.ServiceUUID
 import com.jwoglom.pumpx2.pump.messages.builders.CurrentBatteryRequestBuilder
 import com.jwoglom.pumpx2.pump.messages.helpers.Bytes
 import com.jwoglom.pumpx2.pump.messages.models.ApiVersion
 import com.jwoglom.pumpx2.pump.messages.models.InsulinUnit
 import com.jwoglom.pumpx2.pump.messages.models.KnownApiVersion
-import com.jwoglom.pumpx2.pump.messages.models.KnownDeviceModel
 import com.jwoglom.pumpx2.pump.messages.models.PairingCodeType
 import com.jwoglom.pumpx2.pump.messages.request.control.InitiateBolusRequest
-import com.jwoglom.pumpx2.pump.messages.request.currentStatus.ApiVersionRequest
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.ControlIQIOBRequest
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.HistoryLogStatusRequest
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.InsulinStatusRequest
-import com.jwoglom.pumpx2.pump.messages.request.currentStatus.TimeSinceResetRequest
-import com.jwoglom.pumpx2.pump.messages.response.authentication.AbstractCentralChallengeResponse
-import com.jwoglom.pumpx2.pump.messages.response.authentication.AbstractPumpChallengeResponse
-import com.jwoglom.pumpx2.pump.messages.response.control.BolusPermissionResponse
-import com.jwoglom.pumpx2.pump.messages.response.control.InitiateBolusResponse
 import com.jwoglom.pumpx2.pump.messages.response.currentStatus.ControlIQIOBResponse
-import com.jwoglom.pumpx2.pump.messages.response.currentStatus.CurrentBasalStatusResponse
 import com.jwoglom.pumpx2.pump.messages.response.currentStatus.CurrentBatteryAbstractResponse
-import com.jwoglom.pumpx2.pump.messages.response.currentStatus.CurrentBolusStatusResponse
-import com.jwoglom.pumpx2.pump.messages.response.currentStatus.CurrentEGVGuiDataResponse
-import com.jwoglom.pumpx2.pump.messages.response.currentStatus.HistoryLogStatusResponse
 import com.jwoglom.pumpx2.pump.messages.response.currentStatus.InsulinStatusResponse
-import com.jwoglom.pumpx2.pump.messages.response.currentStatus.TimeSinceResetResponse
-import com.jwoglom.pumpx2.pump.messages.response.historyLog.HistoryLog
-import com.jwoglom.pumpx2.pump.messages.response.historyLog.HistoryLogStreamResponse
-import com.jwoglom.pumpx2.pump.messages.response.qualifyingEvent.QualifyingEvent
 import com.jwoglom.pumpx2.shared.Hex
 import com.welie.blessed.BluetoothPeripheral
-import com.welie.blessed.HciStatus
-import com.welie.blessed.WriteType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import org.bouncycastle.jce.provider.BouncyCastleProvider
-import org.json.JSONObject
 import timber.log.Timber
-import java.security.Security
-import java.time.Duration
 import java.time.Instant
-import com.jwoglom.controlx2.pump.CommServiceCallbacks
-import com.jwoglom.controlx2.pump.PumpCommState
-import com.jwoglom.controlx2.pump.PumpFinderCommHandler
-import java.util.UUID
-import java.util.function.Supplier
 
-
-const val CacheSeconds = 30
 
 class CommService : Service(), CommServiceCallbacks {
     override val supervisorJob = SupervisorJob()
@@ -159,764 +110,8 @@ class CommService : Service(), CommServiceCallbacks {
 
     val historyLogDb by lazy { HistoryLogDatabase.getDatabase(this) }
     override val historyLogRepo by lazy { HistoryLogRepo(historyLogDb.historyLogDao()) }
-    private var historyLogFetcher: HistoryLogFetcher? = null
-    private var historyLogSyncWorker: HistoryLogSyncWorker? = null
 
-    // Handler that receives messages from the thread
-    private inner class PumpCommHandler(looper: Looper) : Handler(looper) {
-        private lateinit var pump: Pump
-        private lateinit var tandemBTHandler: TandemBluetoothHandler
-        var currentSession: PumpSession? = null
-            internal set
-
-        fun getPumpSid(): Int? {
-            return if (this::pump.isInitialized) pump.pumpSid else null
-        }
-
-        fun isPumpReadyForHistoryFetch(): Boolean {
-            return currentSession?.isActive == true
-        }
-
-        @androidx.annotation.VisibleForTesting
-        fun simulateConnectedPump(peripheral: BluetoothPeripheral) {
-            pump.initializeConnection(peripheral)
-        }
-
-        private fun ensurePumpUnbondedForFreshInit(filterToBluetoothMac: String?): Boolean {
-            val targetMac = (filterToBluetoothMac ?: Prefs(applicationContext).pumpFinderPumpMac().orEmpty())
-                .trim()
-                .uppercase()
-            val prefs = Prefs(applicationContext)
-            val scheduledUnbondMac = prefs.unbondOnNextCommInitMac().orEmpty().trim().uppercase()
-
-            if (scheduledUnbondMac.isEmpty()) {
-                Timber.i("init_pump_comm: skipping unbond (not scheduled for this init)")
-                return true
-            }
-
-            if (targetMac.isEmpty()) {
-                Timber.i("init_pump_comm: skipping unbond (no target MAC)")
-                return true
-            }
-
-            if (scheduledUnbondMac != targetMac) {
-                Timber.i("init_pump_comm: skipping unbond for $targetMac (scheduled for $scheduledUnbondMac)")
-                return true
-            }
-
-            // Consume schedule now so this runs only once per re-pair handoff.
-            prefs.setUnbondOnNextCommInitMac(null)
-
-            val adapter = BluetoothAdapter.getDefaultAdapter()
-            if (adapter == null) {
-                Timber.w("init_pump_comm: cannot unbond $targetMac because BluetoothAdapter is null")
-                return true
-            }
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
-                checkSelfPermission(Manifest.permission.BLUETOOTH_CONNECT) != PackageManager.PERMISSION_GRANTED) {
-                Timber.w("init_pump_comm: cannot unbond $targetMac without BLUETOOTH_CONNECT permission")
-                return true
-            }
-
-            val bondedDevice = adapter.bondedDevices
-                ?.firstOrNull { it.address.equals(targetMac, ignoreCase = true) }
-            if (bondedDevice == null) {
-                Timber.i("init_pump_comm: target $targetMac not currently bonded")
-                return true
-            }
-
-            try {
-                val removeBondMethod = bondedDevice.javaClass.getMethod("removeBond")
-                val didRequestUnbond = removeBondMethod.invoke(bondedDevice) as? Boolean ?: false
-                Timber.i("init_pump_comm: requested unbond for ${bondedDevice.name} ($targetMac), result=$didRequestUnbond")
-            } catch (e: SecurityException) {
-                Timber.w(e, "init_pump_comm: missing permission while requesting unbond for $targetMac")
-            } catch (e: Exception) {
-                Timber.w(e, "init_pump_comm: failed unbond request for $targetMac")
-            }
-
-            Thread.sleep(500)
-            val stillBonded = adapter.bondedDevices
-                ?.any { it.address.equals(targetMac, ignoreCase = true) } == true
-            if (!stillBonded) {
-                Timber.i("init_pump_comm: target $targetMac unbonded successfully")
-                return true
-            }
-
-            val details = "${bondedDevice.name ?: "Unknown Tandem device"}=$targetMac"
-            Timber.w("init_pump_comm: target is still bonded after unbond attempt: $details")
-            sendWearCommMessage("/from-pump/pump-bonded-needs-manual-unbond", details.toByteArray())
-            Toast.makeText(
-                this@CommService,
-                "Pump is still bonded in Android Bluetooth settings. Unpair it, then retry.",
-                Toast.LENGTH_LONG
-            ).show()
-            return false
-        }
-
-        private inner class Pump(var tandemConfig: TandemConfig) : TandemPump(applicationContext, tandemConfig) {
-            private val scope = CoroutineScope(SupervisorJob(parent = supervisorJob) + Dispatchers.IO)
-            private val xdripMessageDispatcher = XdripMessageDispatcher(this@CommService)
-            var lastPeripheral: BluetoothPeripheral? = null
-            var isConnected = false
-            var pumpSid: Int? = null
-
-            init {
-                if (Prefs(applicationContext).connectionSharingEnabled()) {
-                    enableTconnectAppConnectionSharing()
-                    enableSendSharedConnectionResponseMessages()
-                    // before adding relyOnConnectionSharingForAuthentication(), callback issues need to be resolved
-                }
-                if (Prefs(applicationContext).onlySnoopBluetoothEnabled()) {
-                    Timber.i("ONLY SNOOP BLUETOOTH ENABLED")
-                    onlySnoopBluetoothAndBlockAllPumpX2Functionality()
-                }
-
-                if (Prefs(applicationContext).insulinDeliveryActions()) {
-                    Timber.i("ACTIONS AFFECTING INSULIN DELIVERY ENABLED")
-                    enableActionsAffectingInsulinDelivery()
-                } else {
-                    Timber.i("Actions affecting insulin delivery are disabled")
-                }
-                Timber.i("Pump init")
-            }
-
-            override fun onReceiveMessage(
-                peripheral: BluetoothPeripheral?,
-                message: com.jwoglom.pumpx2.pump.messages.Message?
-            ) {
-                message?.let {
-                    pumpCommState.lastResponseMessage.put(Pair(it.characteristic, it.opCode()), Pair(it, Instant.now()))
-                    val source = if (consumeDebugPromptResponse(it.characteristic, it.opCode())) {
-                        SendType.DEBUG_PROMPT
-                    } else {
-                        SendType.STANDARD
-                    }
-                    // Propagate to HttpDebugApiService first so API callbacks/streams are not
-                    // blocked by downstream UI-side handling (e.g. debug popup flow).
-                    httpDebugApiService?.onPumpMessageReceived(it, source = source)
-                }
-                sendWearCommMessage("/from-pump/receive-message", PumpMessageSerializer.toBytes(message))
-
-                message?.let {
-                    if (it is CurrentBatteryAbstractResponse ||
-                        it is ControlIQIOBResponse ||
-                        it is CurrentEGVGuiDataResponse
-                    ) {
-                        sendWearCommMessage("/to-wear/service-receive-message", PumpMessageSerializer.toBytes(message))
-                    }
-                }
-
-                // Callbacks handled by this service itself
-                when (message) {
-                    is TimeSinceResetResponse -> onReceiveTimeSinceResetResponse(message)
-                    is InitiateBolusResponse -> onReceiveInitiateBolusResponse(message)
-                    is CurrentBolusStatusResponse -> onReceiveCurrentBolusStatusResponse(message)
-                    is BolusPermissionResponse -> {
-                        PumpStateSupplier.inProgressBolusId = Supplier { message.bolusId }
-                    }
-                    is CurrentBatteryAbstractResponse -> DataClientState(context).pumpBattery = Pair("${message.batteryPercent}", Instant.now())
-                    is ControlIQIOBResponse -> DataClientState(context).pumpIOB = Pair("${InsulinUnit.from1000To1(message.pumpDisplayedIOB)}", Instant.now())
-                    is InsulinStatusResponse -> DataClientState(context).pumpCartridgeUnits = Pair("${message.currentInsulinAmount}", Instant.now())
-                    is CurrentBasalStatusResponse -> DataClientState(context).pumpCurrentBasal = Pair("${InsulinUnit.from1000To1(message.currentBasalRate)}", Instant.now())
-                    is CurrentEGVGuiDataResponse -> DataClientState(context).cgmReading = Pair("${message.cgmReading}", Instant.now())
-                    is HistoryLogStatusResponse -> {
-                        Timber.i("HistoryLogStatusResponse: $message")
-                        scope.launch {
-                            Timber.i("HistoryLogStatusResponse: launching in scope $message")
-                            historyLogFetcher?.onStatusResponse(message, scope)
-                        }
-                    }
-                    is HistoryLogStreamResponse -> {
-                        message.historyLogs.forEach {
-                            Timber.i("HISTORY-LOG-MESSAGE(${it.sequenceNum}): $it")
-                            pumpCommState.historyLogCache[it.sequenceNum] = it
-                            scope.launch {
-                                historyLogFetcher?.onStreamResponse(it)
-                            }
-                        }
-                    }
-                }
-
-                message?.let { xdripMessageDispatcher.onReceiveMessage(it) }
-                message?.let { updateNotificationWithPumpData(it) }
-            }
-
-
-
-            override fun onReceiveQualifyingEvent(
-                peripheral: BluetoothPeripheral?,
-                events: MutableSet<QualifyingEvent>?
-            ) {
-                Timber.i("onReceiveQualifyingEvent: $events")
-                Toast.makeText(this@CommService, "Events: $events", Toast.LENGTH_SHORT).show()
-                if (events != null && QualifyingEvent.PUMP_COMMUNICATIONS_SUSPENDED in events) {
-                    Timber.w("onReceiveQualifyingEvent: PUMP_COMMUNICATIONS_SUSPENDED — pausing sends")
-                    currentSession?.pauseSends(currentSession?.rateLimitConfig?.commSuspendedPauseMs ?: 5_000)
-                }
-                events?.forEach { event ->
-                    event.suggestedHandlers.forEach { handler ->
-                        Timber.i("onReceiveQualifyingEvent: running handler for $event message: ${handler.get()}")
-                        handler.get()?.let { command(it) }
-                    }
-                }
-                sendWearCommMessage("/from-pump/receive-qualifying-event", PumpQualifyingEventsSerializer.toBytes(events))
-            }
-
-            var pairingCodeCentralChallenge: AbstractCentralChallengeResponse? = null
-            override fun onWaitingForPairingCode(
-                peripheral: BluetoothPeripheral?,
-                centralChallengeResponse: AbstractCentralChallengeResponse?
-            ) {
-                pairingCodeCentralChallenge = centralChallengeResponse
-                val hasSavedPairingCode = !PumpState.getPairingCode(context).isNullOrBlank()
-                if (!hasSavedPairingCode) {
-                    val challengeBytes = if (centralChallengeResponse != null) {
-                        PumpMessageSerializer.toBytes(centralChallengeResponse)
-                    } else {
-                        byteArrayOf()
-                    }
-                    Timber.i("onWaitingForPairingCode: no saved pairing code, waiting for user input")
-                    sendWearCommMessage("/from-pump/missing-pairing-code", challengeBytes)
-                    return
-                }
-                Timber.i("onWaitingForPairingCode: saved pairing code found, auto-pairing")
-                performPairing(peripheral, centralChallengeResponse, false)
-            }
-
-            override fun onInvalidPairingCode(
-                peripheral: BluetoothPeripheral?,
-                resp: AbstractPumpChallengeResponse?
-            ) {
-                sendWearCommMessage("/from-pump/invalid-pairing-code", "".toByteArray())
-                super.onInvalidPairingCode(peripheral, resp)
-            }
-
-            fun performPairing(
-                peripheral: BluetoothPeripheral?,
-                centralChallengeResponse: AbstractCentralChallengeResponse?,
-                manuallyTriggered: Boolean
-            ) {
-
-                if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) != null) {
-                    Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
-                }
-                Security.addProvider(BouncyCastleProvider())
-
-                Timber.i("performPairing manuallyTriggered=$manuallyTriggered")
-                var challengeBytes = byteArrayOf()
-                if (centralChallengeResponse != null) {
-                    challengeBytes = PumpMessageSerializer.toBytes(centralChallengeResponse)
-                }
-                PumpState.getPairingCode(context)?.let {
-                    Timber.i("Pairing with saved code: $it centralChallenge: $centralChallengeResponse")
-                    pair(peripheral, centralChallengeResponse, it)
-                    sendWearCommMessage(
-                        "/from-pump/entered-pairing-code",
-                        challengeBytes)
-                } ?: run {
-                    Timber.i("Pairing without saved code: centralChallenge: $centralChallengeResponse")
-                    sendWearCommMessage(
-                        "/from-pump/missing-pairing-code",
-                        challengeBytes)
-                }
-            }
-
-            /**
-             * Callback is not run when the pump is already bonded
-             */
-            override fun onPumpDiscovered(
-                peripheral: BluetoothPeripheral?,
-                scanResult: ScanResult?,
-                readyState: PumpReadyState
-            ): Boolean {
-                sendWearCommMessage(
-                    "/from-pump/pump-discovered",
-                    "${peripheral?.name.orEmpty()};;${readyState.name}".toByteArray()
-                )
-                return super.onPumpDiscovered(peripheral, scanResult, readyState)
-            }
-
-            override fun onInitialPumpConnection(peripheral: BluetoothPeripheral?) {
-                lastPeripheral = peripheral
-                val wait = (500..1000).random()
-                Timber.i("Waiting to pair onInitialPumpConnection to avoid race condition with tconnect app for ${wait}ms")
-                Thread.sleep(wait.toLong())
-
-                sendWearCommMessage("/from-pump/initial-pump-connection", "${peripheral?.name}".toByteArray())
-
-                if (Packetize.txId.get() > 0) {
-                    Timber.w("Not pairing in onInitialPumpConnection because it looks like the tconnect app has already paired with txId=${Packetize.txId.get()}")
-                    return
-                }
-                super.onInitialPumpConnection(peripheral)
-            }
-
-            @androidx.annotation.VisibleForTesting
-            fun initializeConnection(peripheral: BluetoothPeripheral) {
-                lastPeripheral = peripheral
-
-                extractPumpSid(peripheral.name ?: "")?.let {
-                    pumpSid = it
-                    Prefs(applicationContext).setCurrentPumpSid(it)
-                }
-
-                val session = PumpSession.open(this, peripheral)
-                this@PumpCommHandler.currentSession = session
-
-                isConnected = true
-                Timber.i("service initializeConnection: $this")
-                sendWearCommMessage("/from-pump/pump-connected",
-                    peripheral.name!!.toByteArray()
-                )
-                // Sync glucose unit preference to wear app
-                val glucoseUnit = Prefs(applicationContext).glucoseUnit()
-                if (glucoseUnit != null) {
-                    sendWearCommMessage("/to-wear/glucose-unit", glucoseUnit.name.toByteArray())
-                }
-                currentPumpData.connectionTime = Instant.now()
-            }
-
-            private fun initializeHistoryAndSync() {
-                historyLogFetcher = HistoryLogFetcher(
-                    historyLogRepo = this@CommService.historyLogRepo,
-                    pumpSid = pumpSid!!,
-                    pumpSession = this@PumpCommHandler.currentSession!!,
-                    autoFetchEnabled = { Prefs(applicationContext).autoFetchHistoryLogs() },
-                    broadcastCallback = { item -> this@CommService.broadcastHistoryLogItem(item) }
-                )
-                Timber.i("HistoryLogFetcher initialized")
-
-                historyLogSyncWorker = HistoryLogSyncWorker(requestSync = { requestHistoryLogStatusUpdate() })
-                refreshHistoryLogSyncWorker(triggerImmediateSync = true)
-                // Start Nightscout sync worker if enabled
-                NightscoutSyncWorker.startIfEnabled(
-                    applicationContext,
-                    applicationContext.getSharedPreferences("controlx2", Context.MODE_PRIVATE),
-                    pumpSid!!
-                )
-            }
-
-            private fun waitForResponseStabilization() {
-                var numResponses = -99999
-                while (PumpState.processedResponseMessages != numResponses) {
-                    numResponses = PumpState.processedResponseMessages
-                    val wait = (250..500).random()
-                    Timber.i("service onPumpConnected -- waiting for ${wait}ms to avoid race conditions: (processedResponseMessages: ${PumpState.processedResponseMessages})")
-                    Thread.sleep(wait.toLong())
-                }
-            }
-
-            private fun sendBaseCommandsIfNeeded(peripheral: BluetoothPeripheral) {
-                Timber.i("service onPumpConnected -- checking for base messages (processedResponseMessages: ${PumpState.processedResponseMessages})")
-                if (!pumpCommState.lastResponseMessage.containsKey(Pair(Characteristic.CURRENT_STATUS, ApiVersionRequest().opCode()))) {
-                    Timber.i("service onPumpConnected -- sending ApiVersionRequest")
-                    this.sendCommand(peripheral, ApiVersionRequest())
-                }
-
-                if (!pumpCommState.lastResponseMessage.containsKey(Pair(Characteristic.CURRENT_STATUS, TimeSinceResetResponse().opCode()))) {
-                    Timber.i("service onPumpConnected -- sending TimeSinceResetResponse")
-                    this.sendCommand(peripheral, TimeSinceResetRequest())
-                }
-                Thread.sleep(250)
-            }
-
-            override fun onPumpConnected(peripheral: BluetoothPeripheral?) {
-                initializeConnection(peripheral!!)
-                initializeHistoryAndSync()
-                waitForResponseStabilization()
-                sendBaseCommandsIfNeeded(peripheral)
-                updateNotification("Connected to pump")
-            }
-
-            override fun onPumpModel(peripheral: BluetoothPeripheral?, model: KnownDeviceModel?) {
-                super.onPumpModel(peripheral, model)
-                Timber.i("service onPumpModel")
-                sendWearCommMessage("/from-pump/pump-model",
-                    model!!.name.toByteArray()
-                )
-
-                val modelName = when (model) {
-                    KnownDeviceModel.TSLIM_X2 -> "t:slim X2"
-                    KnownDeviceModel.MOBI -> "Tandem Mobi"
-                    else -> "Tandem Pump"
-                }
-                Prefs(this@CommService).setPumpModelName(modelName)
-            }
-
-            override fun onPumpDisconnected(
-                peripheral: BluetoothPeripheral?,
-                status: HciStatus?
-            ): Boolean {
-                Timber.i("service onPumpDisconnected: isConnected=false")
-                currentSession?.close()
-                currentSession = null
-                lastPeripheral = null
-                pumpCommState.lastResponseMessage.clear()
-                historyLogFetcher?.cancel()
-                historyLogFetcher = null
-                historyLogSyncWorker?.stop()
-                historyLogSyncWorker = null
-                pumpCommState.lastTimeSinceReset = null
-                pumpCommState.debugPromptResponseCounts.clear()
-                isConnected = false
-                sendWearCommMessage("/from-pump/pump-disconnected",
-                    peripheral?.name!!.toByteArray()
-                )
-                currentPumpData.connectionTime = Instant.now()
-                updateNotification("Disconnected from pump")
-                Toast.makeText(this@CommService, "Pump disconnected: $status", Toast.LENGTH_SHORT).show();
-                return super.onPumpDisconnected(peripheral, status)
-            }
-
-            override fun onPumpCriticalError(peripheral: BluetoothPeripheral?, reason: TandemError?) {
-                super.onPumpCriticalError(peripheral, reason)
-                Timber.w("onPumpCriticalError $reason")
-                // Complete HttpDebugApiService request callbacks before UI notification side effects.
-                val source = reason?.initiatingMessage?.let {
-                    if (consumeDebugPromptResponse(it.characteristic, it.responseOpCode)) {
-                        SendType.DEBUG_PROMPT
-                    } else {
-                        SendType.STANDARD
-                    }
-                } ?: SendType.STANDARD
-                reason?.let { httpDebugApiService?.onPumpCriticalError(it, source = source) }
-                Toast.makeText(this@CommService, "${reason?.name}: ${reason?.message}", Toast.LENGTH_LONG).show()
-                sendWearCommMessage("/from-pump/pump-critical-error",
-                    reason?.message!!.toByteArray()
-                );
-            }
-
-            @Synchronized
-            fun command(message: com.jwoglom.pumpx2.pump.messages.Message?) {
-                if (message == null) {
-                    Timber.w("Not sending null message")
-                    return
-                }
-
-                if (lastPeripheral == null) {
-                    Timber.w("Not sending message because no saved peripheral yet: $message")
-                    return
-                }
-
-                if (!isConnected) {
-                    Timber.w("Not sending message because no onConnected event yet: $message")
-                    return
-                }
-
-                val session = currentSession
-                if (session == null) {
-                    Timber.w("Not sending message because no active session: $message")
-                    return
-                }
-
-                Timber.i("Pump send command: $message")
-                runBlocking { session.sendCommand(message) }
-            }
-
-            override fun toString(): String {
-                return "Pump(isConnected=$isConnected, lastPeripheral=$lastPeripheral)"
-            }
-
-        }
-
-        
-        private fun onReceiveInitiateBolusResponse(response: InitiateBolusResponse?) {
-            val intent: Intent? = Intent(applicationContext, BolusNotificationBroadcastReceiver::class.java).apply {
-                putExtra("action", "INITIATE_RESPONSE")
-                putExtra("response", PumpMessageSerializer.toBytes(response))
-            }
-            applicationContext.sendBroadcast(intent)
-        }
-
-        private var lastBolusStatusId: Int? = null
-        
-        private fun onReceiveCurrentBolusStatusResponse(response: CurrentBolusStatusResponse?) {
-            if (response != null) {
-                // Broadcast status updates for active boluses (bolusId != 0)
-                // Also broadcast when bolus completes (bolusId becomes 0 after being non-zero)
-                val shouldBroadcast = response.bolusId != 0 || 
-                    (response.bolusId == 0 && lastBolusStatusId != null && lastBolusStatusId != 0)
-                
-                if (shouldBroadcast) {
-                    val intent: Intent? = Intent(applicationContext, BolusNotificationBroadcastReceiver::class.java).apply {
-                        putExtra("action", "STATUS_UPDATE")
-                        putExtra("status", PumpMessageSerializer.toBytes(response))
-                    }
-                    applicationContext.sendBroadcast(intent)
-                }
-                
-                // Track the last bolusId to detect completion (transition from non-zero to zero)
-                lastBolusStatusId = response.bolusId
-                
-                // Clear tracking when bolusId has been 0 for a while (to avoid stale broadcasts)
-                if (response.bolusId == 0) {
-                    // Clear after a delay to allow the completion notification to be sent
-                    pumpCommHandler?.postDelayed({
-                        if (lastBolusStatusId == 0) {
-                            lastBolusStatusId = null
-                        }
-                    }, 2000)
-                }
-            }
-        }
-
-        private fun onReceiveTimeSinceResetResponse(response: TimeSinceResetResponse?) {
-            Timber.i("pumpCommState.lastTimeSinceReset = $response")
-            pumpCommState.lastTimeSinceReset = response
-        }
-
-        private fun pumpConnectedPrecondition(checkConnected: Boolean = true): Boolean {
-            if (!this::pump.isInitialized) {
-                Timber.e("pumpConnectedPrecondition: pump not initialized")
-                sendWearCommMessage("/from-pump/pump-not-connected", "not_initialized".toByteArray())
-            } else if (pump.lastPeripheral == null) {
-                Timber.e("pumpConnectedPrecondition: pump not saved peripheral")
-                sendWearCommMessage("/from-pump/pump-not-connected", "null_peripheral".toByteArray())
-            } else if (checkConnected && !pump.isConnected) {
-                Timber.e("pumpConnectedPrecondition: pump not connected")
-                sendWearCommMessage("/from-pump/pump-not-connected", "not_connected".toByteArray())
-            } else {
-                return true
-            }
-            return false
-        }
-        
-        override fun handleMessage(msg: Message) {
-            when (msg.what) {
-                CommServiceCodes.INIT_PUMP_COMM.ordinal -> {
-                    if (pumpConnectedPrecondition(checkConnected = false)) {
-                        Timber.w("pumpCommHandler: init_pump_comm already run, ignoring")
-                        return
-                    }
-                    try {
-                        var pairingCodeType: PairingCodeType? = null
-                        var filterToBluetoothMac: String? = null
-                        if (msg.obj != null && msg.obj != "") {
-                            var parts = (msg.obj as String).split(" ")
-                            pairingCodeType = PairingCodeType.fromLabel(parts[0])
-                            if (parts.size == 2) {
-                                filterToBluetoothMac = parts[1]
-                            }
-                        }
-
-                        if (!ensurePumpUnbondedForFreshInit(filterToBluetoothMac)) {
-                            return
-                        }
-                        Timber.i("pumpCommHandler: init_pump_comm: msg.obj=${msg.obj as String} pairingCodeType=$pairingCodeType filterToBluetoothMac=$filterToBluetoothMac")
-                        val cfg = TandemConfig()
-                            .withFilterToBluetoothMac(filterToBluetoothMac)
-                            .withPairingCodeType(pairingCodeType)
-
-                        pump = Pump(cfg)
-                        tandemBTHandler =
-                            TandemBluetoothHandler.getInstance(applicationContext, pump, null)
-                    } catch (e: SecurityException) {
-                        Timber.e("pumpCommHandler: SecurityException starting pump $e")
-                    }
-                    while (true) {
-                        try {
-                            Timber.i("pumpCommHandler: Starting scan...")
-                            tandemBTHandler.startScan()
-                            break
-                        } catch (e: SecurityException) {
-                            Timber.e("pumpCommHandler: Waiting for BT permissions $e")
-                            Thread.sleep(500)
-                        }
-                    }
-                }
-                CommServiceCodes.STOP_PUMP_COMM.ordinal -> {
-                    tandemBTHandler.stop()
-                }
-                CommServiceCodes.CHECK_PUMP_CONNECTED.ordinal -> {
-                    if (pumpConnectedPrecondition()) {
-                        sendWearCommMessage("/from-pump/pump-connected",
-                            pump.lastPeripheral?.name!!.toByteArray()
-                        )
-                    }
-                }
-                CommServiceCodes.SEND_PUMP_PAIRING_MESSAGE.ordinal -> {
-                    if (pumpConnectedPrecondition(checkConnected = false)) {
-                        if (pump.lastPeripheral != null && pump.pairingCodeCentralChallenge != null) {
-                            Timber.i("sendPumpPairingMessage: running performPairing")
-                            pump.performPairing(
-                                pump.lastPeripheral,
-                                pump.pairingCodeCentralChallenge,
-                                true
-                            )
-                        } else {
-                            Timber.w("sendPumpPairingMessage: cannot send pump pairing message: lastPeripheral=${pump.lastPeripheral} pairingCodeCentralChallenge=${pump.pairingCodeCentralChallenge}")
-                        }
-                    }
-                }
-                CommServiceCodes.SEND_PUMP_COMMAND.ordinal -> {
-                    Timber.i("pumpCommHandler send command raw: ${String(msg.obj as ByteArray)}")
-                    val pumpMsg = PumpMessageSerializer.fromBytes(msg.obj as ByteArray)
-                    if (isBolusCommand(pumpMsg)) {
-                        Timber.e("SEND_PUMP_COMMAND blocked bolus command")
-                    } else if (pumpConnectedPrecondition()) {
-                        Timber.i("pumpCommHandler send command: $pumpMsg")
-                        pump.command(pumpMsg)
-                    }
-                }
-                CommServiceCodes.SEND_PUMP_COMMANDS_BULK.ordinal -> {
-                    Timber.i("pumpCommHandler send commands raw: ${String(msg.obj as ByteArray)}")
-                    PumpMessageSerializer.fromBulkBytes(msg.obj as ByteArray).forEach {
-                        if (isBolusCommand(it)) {
-                            Timber.e("SEND_PUMP_COMMAND blocked bolus command")
-                        } else if (pumpConnectedPrecondition()) {
-                            Timber.i("pumpCommHandler send command: $it")
-                            pump.command(it)
-                        }
-                    }
-                }
-                CommServiceCodes.SEND_PUMP_COMMANDS_BUST_CACHE_BULK.ordinal -> {
-                    Timber.i("pumpCommHandler send commands bust cache raw: ${String(msg.obj as ByteArray)}")
-                    PumpMessageSerializer.fromBulkBytes(msg.obj as ByteArray).forEach {
-                        if (pumpCommState.lastResponseMessage.containsKey(Pair(it.characteristic, it.responseOpCode)) && !isBolusCommand(it)) {
-                            Timber.i("pumpCommHandler busted cache: $it")
-                            pumpCommState.lastResponseMessage.remove(Pair(it.characteristic, it.responseOpCode))
-                        }
-                        if (isBolusCommand(it)) {
-                            Timber.e("SEND_PUMP_COMMAND blocked bolus command")
-                        } else if (pumpConnectedPrecondition()) {
-                            Timber.i("pumpCommHandler send command bust cache: $it")
-                            pump.command(it)
-                        }
-                    }
-                }
-                CommServiceCodes.CACHED_PUMP_COMMANDS_BULK.ordinal -> {
-                    Timber.i("pumpCommHandler cached pump commands raw: ${String(msg.obj as ByteArray)}")
-                    PumpMessageSerializer.fromBulkBytes(msg.obj as ByteArray).forEach {
-                        if (pumpCommState.lastResponseMessage.containsKey(Pair(it.characteristic, it.responseOpCode)) && !isBolusCommand(it)) {
-                            val response = pumpCommState.lastResponseMessage.get(Pair(it.characteristic, it.responseOpCode))
-                            val ageSeconds = Duration.between(response?.second, Instant.now()).seconds
-                            if (ageSeconds <= CacheSeconds) {
-                                Timber.i("pumpCommHandler cached hit: $response")
-                                sendWearCommMessage(
-                                    "/from-pump/receive-cached-message",
-                                    PumpMessageSerializer.toBytes(response?.first)
-                                )
-                            } else {
-                                Timber.i("pumpCommHandler expired cache hit $ageSeconds sec: $response")
-                                if (!isBolusCommand(it) && pumpConnectedPrecondition()) {
-                                    pump.command(it)
-                                }
-                            }
-                        } else if (isBolusCommand(it)) {
-                            Timber.e("CACHED_PUMP_COMMANDS_BULK blocked bolus command")
-                        } else if (pumpConnectedPrecondition()) {
-                            Timber.i("pumpCommHandler cached miss: $it")
-                            pump.command(it)
-                        }
-                    }
-                }
-                CommServiceCodes.SEND_PUMP_COMMAND_BOLUS.ordinal -> {
-                    Timber.i("pumpCommHandler send bolus raw: ${String(msg.obj as ByteArray)}")
-                    val secretKey = prefs(applicationContext)?.getString("initiateBolusSecret", "") ?: ""
-                    val confirmedBolus =
-                        InitiateConfirmedBolusSerializer.fromBytes(secretKey, msg.obj as ByteArray)
-
-                    val messageOk = confirmedBolus.left
-                    val pumpMsg = confirmedBolus.right
-                    if (!messageOk) {
-                        Timber.w("pumpCommHandler bolus invalid signature")
-                        sendWearCommMessage("/to-wear/bolus-blocked-signature", "WearCommHandler".toByteArray())
-                    } else if (!isBolusCommand(pumpMsg)) {
-                        Timber.e("SEND_PUMP_COMMAND_BOLUS not a bolus command: $pumpMsg")
-                    } else if (pumpConnectedPrecondition()) {
-                        Timber.i("pumpCommHandler send bolus command with valid signature: $pumpMsg")
-                        if (!Prefs(applicationContext).insulinDeliveryActions()) {
-                            Timber.e("No insulin delivery messages enabled -- blocking bolus command $pumpMsg")
-                            sendWearCommMessage("/to-wear/bolus-not-enabled", "from_self".toByteArray())
-                            return
-                        }
-                        try {
-                            pump.command(pumpMsg as InitiateBolusRequest)
-                        } catch (e: Packetize.ActionsAffectingInsulinDeliveryNotEnabledInPumpX2Exception) {
-                            Timber.e(e)
-                            sendWearCommMessage("/to-wear/bolus-not-enabled", "from_pumpx2_lib".toByteArray())
-                        }
-                    }
-                }
-                CommServiceCodes.DEBUG_WRITE_BT_CHARACTERISTIC.ordinal -> {
-                    Timber.i("pumpCommHandler debug_write_bt_characteristic: ${String(msg.obj as ByteArray)}")
-                    try {
-                        val contents = JSONObject(String(msg.obj as ByteArray));
-                        val uuidStr = contents.getString("characteristicUuid")
-                        val uuid = UUID.fromString(uuidStr)
-
-                        val valuesStr = contents.getJSONArray("valuesHex")
-                        var valuesHex = ArrayList<ByteArray>()
-                        for (i in 0..valuesStr.length()) {
-                            valuesHex.add(Hex.decodeHex(valuesStr.getString(i)))
-                        }
-
-                        if (pumpConnectedPrecondition()) {
-                            if (!Prefs(applicationContext).insulinDeliveryActions()) {
-                                return
-                            }
-                            valuesHex.forEach {
-                                Packetize.txId.increment()
-                                pump.lastPeripheral?.writeCharacteristic(
-                                    ServiceUUID.PUMP_SERVICE_UUID,
-                                    uuid,
-                                    it,
-                                    WriteType.WITH_RESPONSE
-                                )
-                            }
-                        }
-                    } catch (e: Exception) {
-                        Timber.e(e)
-                    }
-                }
-                CommServiceCodes.WRITE_CHARACTERISTIC_FAILED_CALLBACK.ordinal -> {
-                    val uuidStr = msg.obj as String
-                    if (pumpConnectedPrecondition(checkConnected = false)) {
-                        if (uuidStr == "${CharacteristicUUID.AUTHORIZATION_CHARACTERISTICS}") {
-                            Timber.w("writeCharacteristicFailedCallback: calling onPumpConnected pump=$pump from authorization error")
-                            pump.onPumpConnected(pump.lastPeripheral)
-                        } else {
-                            Timber.w("writeCharacteristicFailedCallback: triggering disconnection from non-authorization error")
-                            pump.lastPeripheral?.cancelConnection();
-                            pump.lastPeripheral?.let { pump.onPumpDisconnected(it, null) }
-                        }
-                    }
-                }
-                CommServiceCodes.DEBUG_GET_MESSAGE_CACHE.ordinal -> {
-                    Timber.i("pumpCommHandler debug get message cache: $pumpCommState.lastResponseMessage")
-                    sendWearCommMessage("/from-pump/debug-message-cache", PumpMessageSerializer.toDebugMessageCacheBytes(pumpCommState.lastResponseMessage.values))
-                }
-                CommServiceCodes.DEBUG_GET_HISTORYLOG_CACHE.ordinal -> {
-                    Timber.i("pumpCommHandler debug get historylog cache: $pumpCommState.historyLogCache")
-                    if (pumpCommState.historyLogCache.size <= 100) {
-                        sendWearCommMessage(
-                            "/from-pump/debug-historylog-cache",
-                            PumpMessageSerializer.toDebugHistoryLogCacheBytes(pumpCommState.historyLogCache)
-                        )
-                    } else {
-                        pumpCommState.historyLogCache.entries.toList().chunked(100).forEach {
-                            sendWearCommMessage(
-                                "/from-pump/debug-historylog-cache",
-                                PumpMessageSerializer.toDebugHistoryLogCacheBytes(it.associate {
-                                    Pair(it.key, it.value)
-                                })
-                            )
-                        }
-                    }
-                }
-            }
-        }
-
-        fun sendWearCommMessage(path: String, message: ByteArray) {
-            this@CommService.sendWearCommMessage(path, message)
-        }
-
-        private fun isBolusCommand(message: com.jwoglom.pumpx2.pump.messages.Message): Boolean {
-            return (message is InitiateBolusRequest) || (message.opCode() == InitiateBolusRequest().opCode() && message.characteristic == Characteristic.CONTROL)
-        }
-    }
-
+    // PumpCommHandler extracted to pump/PumpCommHandler.kt
     // PumpFinderCommHandler extracted to pump/PumpFinderCommHandler.kt
 
     override fun sendWearCommMessage(path: String, message: ByteArray) {
@@ -924,43 +119,8 @@ class CommService : Service(), CommServiceCallbacks {
         messageBus.sendMessage(path, message, MessageBusSender.COMM_SERVICE)
     }
 
-    enum class BondState(val id: Int) {
-        NOT_BONDED(10),
-        BONDING(11),
-        BONDED(12),
-        ;
-        companion object {
-            private val map = BondState.values().associateBy(BondState::id)
-            fun fromId(type: Int) = map[type]
-        }
-    }
+    // BleChangeReceiver and BondState extracted to pump/BleChangeReceiver.kt
     private var bleChangeReceiver = BleChangeReceiver()
-    inner class BleChangeReceiver: BroadcastReceiver() {
-
-        override fun onReceive(context: Context?, intent: Intent?) {
-            when (intent?.action) {
-                "android.bluetooth.device.action.BOND_STATE_CHANGED" -> {
-                    val bondState = BondState.fromId(intent.getIntExtra(
-                        "android.bluetooth.device.extra.BOND_STATE",
-                        Int.MIN_VALUE
-                    ))
-                    Timber.i("BleChangeReceiver BOND_STATE_CHANGED: $bondState")
-                }
-                "android.bluetooth.adapter.action.STATE_CHANGED" -> {
-                    when (intent.getIntExtra("android.bluetooth.adapter.extra.STATE", Int.MIN_VALUE)) {
-                        10, 13 -> {
-                            // Turned off
-                            Timber.i("BleChangeReceiver STATE_CHANGED: off")
-                        }
-                        12 -> {
-                            // Turned on
-                            Timber.i("BleChangeReceiver STATE_CHANGED: on")
-                        }
-                    }
-                }
-            }
-        }
-    }
 
     private val periodicUpdateIntervalMs: Long = 1000 * 60 * 5 // 5 minutes
     private var periodicUpdateTask: Runnable = Runnable {}
@@ -986,43 +146,12 @@ class CommService : Service(), CommServiceCallbacks {
         }
     }
 
-    private fun requestHistoryLogStatusUpdate() {
-        if (!Prefs(applicationContext).autoFetchHistoryLogs()) {
-            return
-        }
-        sendPumpCommMessages(
-            PumpMessageSerializer.toBulkBytes(
-                listOf(HistoryLogStatusRequest())
-            )
-        )
-    }
-
     fun isPumpReadyForHistoryFetch(): Boolean {
         return pumpCommHandler?.isPumpReadyForHistoryFetch() == true
     }
 
     fun getPumpSession(): PumpSession? {
         return pumpCommHandler?.currentSession
-    }
-
-    private fun refreshHistoryLogSyncWorker(triggerImmediateSync: Boolean = false) {
-        val worker = historyLogSyncWorker
-        if (worker == null) {
-            Timber.i("refreshHistoryLogSyncWorker skipped: worker not initialized")
-            return
-        }
-
-        if (!Prefs(applicationContext).autoFetchHistoryLogs()) {
-            Timber.i("refreshHistoryLogSyncWorker stopping worker")
-            worker.stop()
-            return
-        }
-
-        Timber.i("refreshHistoryLogSyncWorker starting worker")
-        worker.start()
-        if (triggerImmediateSync) {
-            worker.triggerImmediateSync()
-        }
     }
 
     private val checkForUpdatesDelayMs: Long = 1000 * 30 // 30 seconds
@@ -1088,7 +217,7 @@ class CommService : Service(), CommServiceCallbacks {
         if (Prefs(applicationContext).pumpFinderServiceEnabled()) {
             pumpFinderCommHandler = PumpFinderCommHandler(serviceLooper!!, this)
         } else {
-            pumpCommHandler = PumpCommHandler(serviceLooper!!)
+            pumpCommHandler = PumpCommHandler(serviceLooper!!, this)
 
             pumpCommHandler?.postDelayed(periodicUpdateTask, periodicUpdateIntervalMs)
             pumpCommHandler?.postDelayed(checkForUpdatesTask, checkForUpdatesDelayMs)
@@ -1123,7 +252,7 @@ class CommService : Service(), CommServiceCallbacks {
                 sendStopPumpFinderComm()
                 if (String(data) == "init_comm") {
                     pumpFinderCommHandler = null
-                    pumpCommHandler = PumpCommHandler(serviceLooper!!)
+                    pumpCommHandler = PumpCommHandler(serviceLooper!!, this)
                     val filterToMac = Prefs(applicationContext).pumpFinderPumpMac().orEmpty()
                     val pairingCodeType = Prefs(applicationContext).pumpFinderPairingCodeType().orEmpty()
                     val pairingCodeTypeEnum = if (pairingCodeType.isNotEmpty())
@@ -1143,7 +272,7 @@ class CommService : Service(), CommServiceCallbacks {
             "/to-phone/restart-pump-finder" -> {
                 Timber.i("restart-pump-finder")
                 sendStopPumpFinderComm()
-                pumpCommHandler = PumpCommHandler(serviceLooper!!)
+                pumpCommHandler = PumpCommHandler(serviceLooper!!, this)
                 Prefs(applicationContext).setPumpFinderServiceEnabled(true)
                 Timber.i("restart-pump-finder")
                 triggerAppReload(applicationContext)
@@ -1163,7 +292,7 @@ class CommService : Service(), CommServiceCallbacks {
             }
             "/to-phone/refresh-history-log-sync" -> {
                 Timber.i("refresh-history-log-sync received")
-                refreshHistoryLogSyncWorker(triggerImmediateSync = true)
+                pumpCommHandler?.refreshHistoryLogSyncWorker(triggerImmediateSync = true)
             }
             "/to-phone/service-status-acknowledged" -> {
                 Timber.i("service-status acknowledged, stopping periodic sender")
@@ -1255,6 +384,10 @@ class CommService : Service(), CommServiceCallbacks {
 
     override fun showToast(text: String, duration: Int) {
         Toast.makeText(this, text, duration).show()
+    }
+
+    override fun getWearPrefs(): SharedPreferences? {
+        return getSharedPreferences("WearX2", MODE_PRIVATE)
     }
 
     private var started = false
@@ -1418,7 +551,7 @@ class CommService : Service(), CommServiceCallbacks {
             pumpCommHandler?.sendMessage(msg)
         }
     }
-    private fun sendPumpCommMessages(pumpMsgBytes: ByteArray) {
+    override fun sendPumpCommMessages(pumpMsgBytes: ByteArray) {
         pumpCommHandler?.obtainMessage()?.also { msg ->
             msg.what = CommServiceCodes.SEND_PUMP_COMMANDS_BULK.ordinal
             msg.obj = pumpMsgBytes
@@ -1654,8 +787,7 @@ class CommService : Service(), CommServiceCallbacks {
 
     override fun onDestroy() {
         super.onDestroy()
-        historyLogSyncWorker?.stop()
-        historyLogSyncWorker = null
+        pumpCommHandler?.stopHistoryLogSyncWorker()
         scope.cancel()
         messageBus.close()
         httpDebugApiService?.stop()

--- a/mobile/src/main/java/com/jwoglom/controlx2/pump/BleChangeReceiver.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/pump/BleChangeReceiver.kt
@@ -1,0 +1,41 @@
+package com.jwoglom.controlx2.pump
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import timber.log.Timber
+
+enum class BondState(val id: Int) {
+    NOT_BONDED(10),
+    BONDING(11),
+    BONDED(12),
+    ;
+    companion object {
+        private val map = BondState.values().associateBy(BondState::id)
+        fun fromId(type: Int) = map[type]
+    }
+}
+
+class BleChangeReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context?, intent: Intent?) {
+        when (intent?.action) {
+            "android.bluetooth.device.action.BOND_STATE_CHANGED" -> {
+                val bondState = BondState.fromId(intent.getIntExtra(
+                    "android.bluetooth.device.extra.BOND_STATE",
+                    Int.MIN_VALUE
+                ))
+                Timber.i("BleChangeReceiver BOND_STATE_CHANGED: $bondState")
+            }
+            "android.bluetooth.adapter.action.STATE_CHANGED" -> {
+                when (intent.getIntExtra("android.bluetooth.adapter.extra.STATE", Int.MIN_VALUE)) {
+                    10, 13 -> {
+                        Timber.i("BleChangeReceiver STATE_CHANGED: off")
+                    }
+                    12 -> {
+                        Timber.i("BleChangeReceiver STATE_CHANGED: on")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/mobile/src/main/java/com/jwoglom/controlx2/pump/CommServiceCallbacks.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/pump/CommServiceCallbacks.kt
@@ -1,6 +1,7 @@
 package com.jwoglom.controlx2.pump
 
 import android.content.Context
+import android.content.SharedPreferences
 import com.jwoglom.controlx2.HttpDebugApiService
 import com.jwoglom.controlx2.db.historylog.HistoryLogItem
 import com.jwoglom.controlx2.db.historylog.HistoryLogRepo
@@ -22,4 +23,6 @@ interface CommServiceCallbacks {
     fun broadcastHistoryLogItem(item: HistoryLogItem)
     fun markConnectionTime()
     fun showToast(text: String, duration: Int)
+    fun getWearPrefs(): SharedPreferences?
+    fun sendPumpCommMessages(pumpMsgBytes: ByteArray)
 }

--- a/mobile/src/main/java/com/jwoglom/controlx2/pump/PumpCommHandler.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/pump/PumpCommHandler.kt
@@ -1,0 +1,847 @@
+package com.jwoglom.controlx2.pump
+
+import android.Manifest
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.le.ScanResult
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.os.Message
+import android.widget.Toast
+import com.jwoglom.controlx2.Prefs
+import com.jwoglom.controlx2.shared.CommServiceCodes
+import com.jwoglom.controlx2.shared.InitiateConfirmedBolusSerializer
+import com.jwoglom.controlx2.shared.PumpMessageSerializer
+import com.jwoglom.controlx2.sync.nightscout.NightscoutSyncWorker
+import com.jwoglom.controlx2.sync.xdrip.XdripMessageDispatcher
+import com.jwoglom.controlx2.util.DataClientState
+import com.jwoglom.controlx2.util.HistoryLogFetcher
+import com.jwoglom.controlx2.util.HistoryLogSyncWorker
+import com.jwoglom.controlx2.util.extractPumpSid
+import com.jwoglom.pumpx2.pump.PumpState
+import com.jwoglom.pumpx2.pump.TandemError
+import com.jwoglom.pumpx2.pump.bluetooth.PumpReadyState
+import com.jwoglom.pumpx2.pump.bluetooth.TandemBluetoothHandler
+import com.jwoglom.pumpx2.pump.bluetooth.TandemConfig
+import com.jwoglom.pumpx2.pump.bluetooth.TandemPump
+import com.jwoglom.pumpx2.pump.messages.Packetize
+import com.jwoglom.pumpx2.pump.messages.bluetooth.Characteristic
+import com.jwoglom.pumpx2.pump.messages.bluetooth.CharacteristicUUID
+import com.jwoglom.pumpx2.pump.messages.bluetooth.PumpStateSupplier
+import com.jwoglom.pumpx2.pump.messages.bluetooth.ServiceUUID
+import com.jwoglom.pumpx2.pump.messages.models.InsulinUnit
+import com.jwoglom.pumpx2.pump.messages.models.KnownDeviceModel
+import com.jwoglom.pumpx2.pump.messages.models.PairingCodeType
+import com.jwoglom.pumpx2.pump.messages.request.control.InitiateBolusRequest
+import com.jwoglom.pumpx2.pump.messages.request.currentStatus.ApiVersionRequest
+import com.jwoglom.pumpx2.pump.messages.request.currentStatus.TimeSinceResetRequest
+import com.jwoglom.pumpx2.pump.messages.response.authentication.AbstractCentralChallengeResponse
+import com.jwoglom.pumpx2.pump.messages.response.authentication.AbstractPumpChallengeResponse
+import com.jwoglom.pumpx2.pump.messages.response.control.BolusPermissionResponse
+import com.jwoglom.pumpx2.pump.messages.response.control.InitiateBolusResponse
+import com.jwoglom.pumpx2.pump.messages.response.currentStatus.ControlIQIOBResponse
+import com.jwoglom.pumpx2.pump.messages.response.currentStatus.CurrentBasalStatusResponse
+import com.jwoglom.pumpx2.pump.messages.response.currentStatus.CurrentBatteryAbstractResponse
+import com.jwoglom.pumpx2.pump.messages.response.currentStatus.CurrentBolusStatusResponse
+import com.jwoglom.pumpx2.pump.messages.response.currentStatus.CurrentEGVGuiDataResponse
+import com.jwoglom.pumpx2.pump.messages.response.currentStatus.HistoryLogStatusResponse
+import com.jwoglom.pumpx2.pump.messages.response.currentStatus.InsulinStatusResponse
+import com.jwoglom.pumpx2.pump.messages.response.currentStatus.TimeSinceResetResponse
+import com.jwoglom.pumpx2.pump.messages.response.historyLog.HistoryLogStreamResponse
+import com.jwoglom.pumpx2.pump.messages.response.qualifyingEvent.QualifyingEvent
+import com.jwoglom.pumpx2.shared.Hex
+import com.welie.blessed.BluetoothPeripheral
+import com.welie.blessed.HciStatus
+import com.welie.blessed.WriteType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.json.JSONObject
+import timber.log.Timber
+import java.security.Security
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+import java.util.function.Supplier
+
+const val CacheSeconds = 30
+
+/**
+ * Handler for pump communication. Manages the TandemPump connection lifecycle,
+ * message routing, response caching, and bolus command handling.
+ *
+ * Extracted from CommService's inner class to enable independent testing.
+ */
+class PumpCommHandler(
+    looper: Looper,
+    private val callbacks: CommServiceCallbacks
+) : Handler(looper) {
+    private lateinit var pump: Pump
+    private lateinit var tandemBTHandler: TandemBluetoothHandler
+    var currentSession: PumpSession? = null
+        internal set
+
+    private var historyLogFetcher: HistoryLogFetcher? = null
+    private var historyLogSyncWorker: HistoryLogSyncWorker? = null
+
+    fun getPumpSid(): Int? {
+        return if (this::pump.isInitialized) pump.pumpSid else null
+    }
+
+    fun isPumpReadyForHistoryFetch(): Boolean {
+        return currentSession?.isActive == true
+    }
+
+    @androidx.annotation.VisibleForTesting
+    fun simulateConnectedPump(peripheral: BluetoothPeripheral) {
+        pump.initializeConnection(peripheral)
+    }
+
+    fun stopHistoryLogSyncWorker() {
+        historyLogSyncWorker?.stop()
+        historyLogSyncWorker = null
+    }
+
+    fun refreshHistoryLogSyncWorker(triggerImmediateSync: Boolean = false) {
+        val worker = historyLogSyncWorker
+        if (worker == null) {
+            Timber.i("refreshHistoryLogSyncWorker skipped: worker not initialized")
+            return
+        }
+
+        if (!Prefs(callbacks.getApplicationContext()).autoFetchHistoryLogs()) {
+            Timber.i("refreshHistoryLogSyncWorker stopping worker")
+            worker.stop()
+            return
+        }
+
+        Timber.i("refreshHistoryLogSyncWorker starting worker")
+        worker.start()
+        if (triggerImmediateSync) {
+            worker.triggerImmediateSync()
+        }
+    }
+
+    private fun requestHistoryLogStatusUpdate() {
+        if (!Prefs(callbacks.getApplicationContext()).autoFetchHistoryLogs()) {
+            return
+        }
+        callbacks.sendPumpCommMessages(
+            PumpMessageSerializer.toBulkBytes(
+                listOf(com.jwoglom.pumpx2.pump.messages.request.currentStatus.HistoryLogStatusRequest())
+            )
+        )
+    }
+
+    private fun ensurePumpUnbondedForFreshInit(filterToBluetoothMac: String?): Boolean {
+        val ctx = callbacks.getApplicationContext()
+        val targetMac = (filterToBluetoothMac ?: Prefs(ctx).pumpFinderPumpMac().orEmpty())
+            .trim()
+            .uppercase()
+        val prefs = Prefs(ctx)
+        val scheduledUnbondMac = prefs.unbondOnNextCommInitMac().orEmpty().trim().uppercase()
+
+        if (scheduledUnbondMac.isEmpty()) {
+            Timber.i("init_pump_comm: skipping unbond (not scheduled for this init)")
+            return true
+        }
+
+        if (targetMac.isEmpty()) {
+            Timber.i("init_pump_comm: skipping unbond (no target MAC)")
+            return true
+        }
+
+        if (scheduledUnbondMac != targetMac) {
+            Timber.i("init_pump_comm: skipping unbond for $targetMac (scheduled for $scheduledUnbondMac)")
+            return true
+        }
+
+        prefs.setUnbondOnNextCommInitMac(null)
+
+        val adapter = BluetoothAdapter.getDefaultAdapter()
+        if (adapter == null) {
+            Timber.w("init_pump_comm: cannot unbond $targetMac because BluetoothAdapter is null")
+            return true
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+            ctx.checkSelfPermission(Manifest.permission.BLUETOOTH_CONNECT) != PackageManager.PERMISSION_GRANTED) {
+            Timber.w("init_pump_comm: cannot unbond $targetMac without BLUETOOTH_CONNECT permission")
+            return true
+        }
+
+        val bondedDevice = adapter.bondedDevices
+            ?.firstOrNull { it.address.equals(targetMac, ignoreCase = true) }
+        if (bondedDevice == null) {
+            Timber.i("init_pump_comm: target $targetMac not currently bonded")
+            return true
+        }
+
+        try {
+            val removeBondMethod = bondedDevice.javaClass.getMethod("removeBond")
+            val didRequestUnbond = removeBondMethod.invoke(bondedDevice) as? Boolean ?: false
+            Timber.i("init_pump_comm: requested unbond for ${bondedDevice.name} ($targetMac), result=$didRequestUnbond")
+        } catch (e: SecurityException) {
+            Timber.w(e, "init_pump_comm: missing permission while requesting unbond for $targetMac")
+        } catch (e: Exception) {
+            Timber.w(e, "init_pump_comm: failed unbond request for $targetMac")
+        }
+
+        Thread.sleep(500)
+        val stillBonded = adapter.bondedDevices
+            ?.any { it.address.equals(targetMac, ignoreCase = true) } == true
+        if (!stillBonded) {
+            Timber.i("init_pump_comm: target $targetMac unbonded successfully")
+            return true
+        }
+
+        val details = "${bondedDevice.name ?: "Unknown Tandem device"}=$targetMac"
+        Timber.w("init_pump_comm: target is still bonded after unbond attempt: $details")
+        callbacks.sendWearCommMessage("/from-pump/pump-bonded-needs-manual-unbond", details.toByteArray())
+        callbacks.showToast(
+            "Pump is still bonded in Android Bluetooth settings. Unpair it, then retry.",
+            Toast.LENGTH_LONG
+        )
+        return false
+    }
+
+    private inner class Pump(var tandemConfig: TandemConfig) : TandemPump(callbacks.getApplicationContext(), tandemConfig) {
+        private val scope = CoroutineScope(SupervisorJob(parent = callbacks.supervisorJob) + Dispatchers.IO)
+        private val xdripMessageDispatcher = XdripMessageDispatcher(callbacks.getApplicationContext())
+        var lastPeripheral: BluetoothPeripheral? = null
+        var isConnected = false
+        var pumpSid: Int? = null
+
+        init {
+            val ctx = callbacks.getApplicationContext()
+            if (Prefs(ctx).connectionSharingEnabled()) {
+                enableTconnectAppConnectionSharing()
+                enableSendSharedConnectionResponseMessages()
+            }
+            if (Prefs(ctx).onlySnoopBluetoothEnabled()) {
+                Timber.i("ONLY SNOOP BLUETOOTH ENABLED")
+                onlySnoopBluetoothAndBlockAllPumpX2Functionality()
+            }
+
+            if (Prefs(ctx).insulinDeliveryActions()) {
+                Timber.i("ACTIONS AFFECTING INSULIN DELIVERY ENABLED")
+                enableActionsAffectingInsulinDelivery()
+            } else {
+                Timber.i("Actions affecting insulin delivery are disabled")
+            }
+            Timber.i("Pump init")
+        }
+
+        override fun onReceiveMessage(
+            peripheral: BluetoothPeripheral?,
+            message: com.jwoglom.pumpx2.pump.messages.Message?
+        ) {
+            message?.let {
+                callbacks.pumpCommState.lastResponseMessage.put(Pair(it.characteristic, it.opCode()), Pair(it, Instant.now()))
+                val source = if (callbacks.pumpCommState.consumeDebugPromptResponse(it.characteristic, it.opCode())) {
+                    com.jwoglom.controlx2.shared.util.SendType.DEBUG_PROMPT
+                } else {
+                    com.jwoglom.controlx2.shared.util.SendType.STANDARD
+                }
+                callbacks.httpDebugApiService?.onPumpMessageReceived(it, source = source)
+            }
+            callbacks.sendWearCommMessage("/from-pump/receive-message", PumpMessageSerializer.toBytes(message))
+
+            message?.let {
+                if (it is CurrentBatteryAbstractResponse ||
+                    it is ControlIQIOBResponse ||
+                    it is CurrentEGVGuiDataResponse
+                ) {
+                    callbacks.sendWearCommMessage("/to-wear/service-receive-message", PumpMessageSerializer.toBytes(message))
+                }
+            }
+
+            when (message) {
+                is TimeSinceResetResponse -> onReceiveTimeSinceResetResponse(message)
+                is InitiateBolusResponse -> onReceiveInitiateBolusResponse(message)
+                is CurrentBolusStatusResponse -> onReceiveCurrentBolusStatusResponse(message)
+                is BolusPermissionResponse -> {
+                    PumpStateSupplier.inProgressBolusId = Supplier { message.bolusId }
+                }
+                is CurrentBatteryAbstractResponse -> DataClientState(context).pumpBattery = Pair("${message.batteryPercent}", Instant.now())
+                is ControlIQIOBResponse -> DataClientState(context).pumpIOB = Pair("${InsulinUnit.from1000To1(message.pumpDisplayedIOB)}", Instant.now())
+                is InsulinStatusResponse -> DataClientState(context).pumpCartridgeUnits = Pair("${message.currentInsulinAmount}", Instant.now())
+                is CurrentBasalStatusResponse -> DataClientState(context).pumpCurrentBasal = Pair("${InsulinUnit.from1000To1(message.currentBasalRate)}", Instant.now())
+                is CurrentEGVGuiDataResponse -> DataClientState(context).cgmReading = Pair("${message.cgmReading}", Instant.now())
+                is HistoryLogStatusResponse -> {
+                    Timber.i("HistoryLogStatusResponse: $message")
+                    scope.launch {
+                        Timber.i("HistoryLogStatusResponse: launching in scope $message")
+                        historyLogFetcher?.onStatusResponse(message, scope)
+                    }
+                }
+                is HistoryLogStreamResponse -> {
+                    message.historyLogs.forEach {
+                        Timber.i("HISTORY-LOG-MESSAGE(${it.sequenceNum}): $it")
+                        callbacks.pumpCommState.historyLogCache[it.sequenceNum] = it
+                        scope.launch {
+                            historyLogFetcher?.onStreamResponse(it)
+                        }
+                    }
+                }
+            }
+
+            message?.let { xdripMessageDispatcher.onReceiveMessage(it) }
+            message?.let { callbacks.updateNotificationWithPumpData(it) }
+        }
+
+        override fun onReceiveQualifyingEvent(
+            peripheral: BluetoothPeripheral?,
+            events: MutableSet<QualifyingEvent>?
+        ) {
+            Timber.i("onReceiveQualifyingEvent: $events")
+            callbacks.showToast("Events: $events", Toast.LENGTH_SHORT)
+            if (events != null && QualifyingEvent.PUMP_COMMUNICATIONS_SUSPENDED in events) {
+                Timber.w("onReceiveQualifyingEvent: PUMP_COMMUNICATIONS_SUSPENDED — pausing sends")
+                currentSession?.pauseSends(currentSession?.rateLimitConfig?.commSuspendedPauseMs ?: 5_000)
+            }
+            events?.forEach { event ->
+                event.suggestedHandlers.forEach { handler ->
+                    Timber.i("onReceiveQualifyingEvent: running handler for $event message: ${handler.get()}")
+                    handler.get()?.let { command(it) }
+                }
+            }
+            callbacks.sendWearCommMessage("/from-pump/receive-qualifying-event", com.jwoglom.controlx2.shared.PumpQualifyingEventsSerializer.toBytes(events))
+        }
+
+        var pairingCodeCentralChallenge: AbstractCentralChallengeResponse? = null
+        override fun onWaitingForPairingCode(
+            peripheral: BluetoothPeripheral?,
+            centralChallengeResponse: AbstractCentralChallengeResponse?
+        ) {
+            pairingCodeCentralChallenge = centralChallengeResponse
+            val hasSavedPairingCode = !PumpState.getPairingCode(context).isNullOrBlank()
+            if (!hasSavedPairingCode) {
+                val challengeBytes = if (centralChallengeResponse != null) {
+                    PumpMessageSerializer.toBytes(centralChallengeResponse)
+                } else {
+                    byteArrayOf()
+                }
+                Timber.i("onWaitingForPairingCode: no saved pairing code, waiting for user input")
+                callbacks.sendWearCommMessage("/from-pump/missing-pairing-code", challengeBytes)
+                return
+            }
+            Timber.i("onWaitingForPairingCode: saved pairing code found, auto-pairing")
+            performPairing(peripheral, centralChallengeResponse, false)
+        }
+
+        override fun onInvalidPairingCode(
+            peripheral: BluetoothPeripheral?,
+            resp: AbstractPumpChallengeResponse?
+        ) {
+            callbacks.sendWearCommMessage("/from-pump/invalid-pairing-code", "".toByteArray())
+            super.onInvalidPairingCode(peripheral, resp)
+        }
+
+        fun performPairing(
+            peripheral: BluetoothPeripheral?,
+            centralChallengeResponse: AbstractCentralChallengeResponse?,
+            manuallyTriggered: Boolean
+        ) {
+            if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) != null) {
+                Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
+            }
+            Security.addProvider(BouncyCastleProvider())
+
+            Timber.i("performPairing manuallyTriggered=$manuallyTriggered")
+            var challengeBytes = byteArrayOf()
+            if (centralChallengeResponse != null) {
+                challengeBytes = PumpMessageSerializer.toBytes(centralChallengeResponse)
+            }
+            PumpState.getPairingCode(context)?.let {
+                Timber.i("Pairing with saved code: $it centralChallenge: $centralChallengeResponse")
+                pair(peripheral, centralChallengeResponse, it)
+                callbacks.sendWearCommMessage("/from-pump/entered-pairing-code", challengeBytes)
+            } ?: run {
+                Timber.i("Pairing without saved code: centralChallenge: $centralChallengeResponse")
+                callbacks.sendWearCommMessage("/from-pump/missing-pairing-code", challengeBytes)
+            }
+        }
+
+        override fun onPumpDiscovered(
+            peripheral: BluetoothPeripheral?,
+            scanResult: ScanResult?,
+            readyState: PumpReadyState
+        ): Boolean {
+            callbacks.sendWearCommMessage(
+                "/from-pump/pump-discovered",
+                "${peripheral?.name.orEmpty()};;${readyState.name}".toByteArray()
+            )
+            return super.onPumpDiscovered(peripheral, scanResult, readyState)
+        }
+
+        override fun onInitialPumpConnection(peripheral: BluetoothPeripheral?) {
+            lastPeripheral = peripheral
+            val wait = (500..1000).random()
+            Timber.i("Waiting to pair onInitialPumpConnection to avoid race condition with tconnect app for ${wait}ms")
+            Thread.sleep(wait.toLong())
+
+            callbacks.sendWearCommMessage("/from-pump/initial-pump-connection", "${peripheral?.name}".toByteArray())
+
+            if (Packetize.txId.get() > 0) {
+                Timber.w("Not pairing in onInitialPumpConnection because it looks like the tconnect app has already paired with txId=${Packetize.txId.get()}")
+                return
+            }
+            super.onInitialPumpConnection(peripheral)
+        }
+
+        @androidx.annotation.VisibleForTesting
+        fun initializeConnection(peripheral: BluetoothPeripheral) {
+            lastPeripheral = peripheral
+
+            extractPumpSid(peripheral.name ?: "")?.let {
+                pumpSid = it
+                Prefs(callbacks.getApplicationContext()).setCurrentPumpSid(it)
+            }
+
+            val session = PumpSession.open(this, peripheral)
+            this@PumpCommHandler.currentSession = session
+
+            isConnected = true
+            Timber.i("service initializeConnection: $this")
+            callbacks.sendWearCommMessage("/from-pump/pump-connected",
+                peripheral.name!!.toByteArray()
+            )
+            val glucoseUnit = Prefs(callbacks.getApplicationContext()).glucoseUnit()
+            if (glucoseUnit != null) {
+                callbacks.sendWearCommMessage("/to-wear/glucose-unit", glucoseUnit.name.toByteArray())
+            }
+            callbacks.markConnectionTime()
+        }
+
+        private fun initializeHistoryAndSync() {
+            historyLogFetcher = HistoryLogFetcher(
+                historyLogRepo = callbacks.historyLogRepo,
+                pumpSid = pumpSid!!,
+                pumpSession = this@PumpCommHandler.currentSession!!,
+                autoFetchEnabled = { Prefs(callbacks.getApplicationContext()).autoFetchHistoryLogs() },
+                broadcastCallback = { item -> callbacks.broadcastHistoryLogItem(item) }
+            )
+            Timber.i("HistoryLogFetcher initialized")
+
+            historyLogSyncWorker = HistoryLogSyncWorker(requestSync = { requestHistoryLogStatusUpdate() })
+            refreshHistoryLogSyncWorker(triggerImmediateSync = true)
+            val ctx = callbacks.getApplicationContext()
+            NightscoutSyncWorker.startIfEnabled(
+                ctx,
+                ctx.getSharedPreferences("controlx2", Context.MODE_PRIVATE),
+                pumpSid!!
+            )
+        }
+
+        private fun waitForResponseStabilization() {
+            var numResponses = -99999
+            while (PumpState.processedResponseMessages != numResponses) {
+                numResponses = PumpState.processedResponseMessages
+                val wait = (250..500).random()
+                Timber.i("service onPumpConnected -- waiting for ${wait}ms to avoid race conditions: (processedResponseMessages: ${PumpState.processedResponseMessages})")
+                Thread.sleep(wait.toLong())
+            }
+        }
+
+        private fun sendBaseCommandsIfNeeded(peripheral: BluetoothPeripheral) {
+            Timber.i("service onPumpConnected -- checking for base messages (processedResponseMessages: ${PumpState.processedResponseMessages})")
+            if (!callbacks.pumpCommState.lastResponseMessage.containsKey(Pair(Characteristic.CURRENT_STATUS, ApiVersionRequest().opCode()))) {
+                Timber.i("service onPumpConnected -- sending ApiVersionRequest")
+                this.sendCommand(peripheral, ApiVersionRequest())
+            }
+
+            if (!callbacks.pumpCommState.lastResponseMessage.containsKey(Pair(Characteristic.CURRENT_STATUS, TimeSinceResetResponse().opCode()))) {
+                Timber.i("service onPumpConnected -- sending TimeSinceResetResponse")
+                this.sendCommand(peripheral, TimeSinceResetRequest())
+            }
+            Thread.sleep(250)
+        }
+
+        override fun onPumpConnected(peripheral: BluetoothPeripheral?) {
+            initializeConnection(peripheral!!)
+            initializeHistoryAndSync()
+            waitForResponseStabilization()
+            sendBaseCommandsIfNeeded(peripheral)
+            callbacks.updateNotification("Connected to pump")
+        }
+
+        override fun onPumpModel(peripheral: BluetoothPeripheral?, model: KnownDeviceModel?) {
+            super.onPumpModel(peripheral, model)
+            Timber.i("service onPumpModel")
+            callbacks.sendWearCommMessage("/from-pump/pump-model",
+                model!!.name.toByteArray()
+            )
+
+            val modelName = when (model) {
+                KnownDeviceModel.TSLIM_X2 -> "t:slim X2"
+                KnownDeviceModel.MOBI -> "Tandem Mobi"
+                else -> "Tandem Pump"
+            }
+            Prefs(callbacks.getApplicationContext()).setPumpModelName(modelName)
+        }
+
+        override fun onPumpDisconnected(
+            peripheral: BluetoothPeripheral?,
+            status: HciStatus?
+        ): Boolean {
+            Timber.i("service onPumpDisconnected: isConnected=false")
+            currentSession?.close()
+            currentSession = null
+            lastPeripheral = null
+            callbacks.pumpCommState.lastResponseMessage.clear()
+            historyLogFetcher?.cancel()
+            historyLogFetcher = null
+            historyLogSyncWorker?.stop()
+            historyLogSyncWorker = null
+            callbacks.pumpCommState.lastTimeSinceReset = null
+            callbacks.pumpCommState.debugPromptResponseCounts.clear()
+            isConnected = false
+            callbacks.sendWearCommMessage("/from-pump/pump-disconnected",
+                peripheral?.name!!.toByteArray()
+            )
+            callbacks.markConnectionTime()
+            callbacks.updateNotification("Disconnected from pump")
+            callbacks.showToast("Pump disconnected: $status", Toast.LENGTH_SHORT)
+            return super.onPumpDisconnected(peripheral, status)
+        }
+
+        override fun onPumpCriticalError(peripheral: BluetoothPeripheral?, reason: TandemError?) {
+            super.onPumpCriticalError(peripheral, reason)
+            Timber.w("onPumpCriticalError $reason")
+            val source = reason?.initiatingMessage?.let {
+                if (callbacks.pumpCommState.consumeDebugPromptResponse(it.characteristic, it.responseOpCode)) {
+                    com.jwoglom.controlx2.shared.util.SendType.DEBUG_PROMPT
+                } else {
+                    com.jwoglom.controlx2.shared.util.SendType.STANDARD
+                }
+            } ?: com.jwoglom.controlx2.shared.util.SendType.STANDARD
+            reason?.let { callbacks.httpDebugApiService?.onPumpCriticalError(it, source = source) }
+            callbacks.showToast("${reason?.name}: ${reason?.message}", Toast.LENGTH_LONG)
+            callbacks.sendWearCommMessage("/from-pump/pump-critical-error",
+                reason?.message!!.toByteArray()
+            )
+        }
+
+        @Synchronized
+        fun command(message: com.jwoglom.pumpx2.pump.messages.Message?) {
+            if (message == null) {
+                Timber.w("Not sending null message")
+                return
+            }
+
+            if (lastPeripheral == null) {
+                Timber.w("Not sending message because no saved peripheral yet: $message")
+                return
+            }
+
+            if (!isConnected) {
+                Timber.w("Not sending message because no onConnected event yet: $message")
+                return
+            }
+
+            val session = currentSession
+            if (session == null) {
+                Timber.w("Not sending message because no active session: $message")
+                return
+            }
+
+            Timber.i("Pump send command: $message")
+            runBlocking { session.sendCommand(message) }
+        }
+
+        override fun toString(): String {
+            return "Pump(isConnected=$isConnected, lastPeripheral=$lastPeripheral)"
+        }
+    }
+
+    private fun onReceiveInitiateBolusResponse(response: InitiateBolusResponse?) {
+        val intent = android.content.Intent(callbacks.getApplicationContext(), com.jwoglom.controlx2.BolusNotificationBroadcastReceiver::class.java).apply {
+            putExtra("action", "INITIATE_RESPONSE")
+            putExtra("response", PumpMessageSerializer.toBytes(response))
+        }
+        callbacks.getApplicationContext().sendBroadcast(intent)
+    }
+
+    private var lastBolusStatusId: Int? = null
+
+    private fun onReceiveCurrentBolusStatusResponse(response: CurrentBolusStatusResponse?) {
+        if (response != null) {
+            val shouldBroadcast = response.bolusId != 0 ||
+                (response.bolusId == 0 && lastBolusStatusId != null && lastBolusStatusId != 0)
+
+            if (shouldBroadcast) {
+                val intent = android.content.Intent(callbacks.getApplicationContext(), com.jwoglom.controlx2.BolusNotificationBroadcastReceiver::class.java).apply {
+                    putExtra("action", "STATUS_UPDATE")
+                    putExtra("status", PumpMessageSerializer.toBytes(response))
+                }
+                callbacks.getApplicationContext().sendBroadcast(intent)
+            }
+
+            lastBolusStatusId = response.bolusId
+
+            if (response.bolusId == 0) {
+                this.postDelayed({
+                    if (lastBolusStatusId == 0) {
+                        lastBolusStatusId = null
+                    }
+                }, 2000)
+            }
+        }
+    }
+
+    private fun onReceiveTimeSinceResetResponse(response: TimeSinceResetResponse?) {
+        Timber.i("pumpCommState.lastTimeSinceReset = $response")
+        callbacks.pumpCommState.lastTimeSinceReset = response
+    }
+
+    private fun pumpConnectedPrecondition(checkConnected: Boolean = true): Boolean {
+        if (!this::pump.isInitialized) {
+            Timber.e("pumpConnectedPrecondition: pump not initialized")
+            callbacks.sendWearCommMessage("/from-pump/pump-not-connected", "not_initialized".toByteArray())
+        } else if (pump.lastPeripheral == null) {
+            Timber.e("pumpConnectedPrecondition: pump not saved peripheral")
+            callbacks.sendWearCommMessage("/from-pump/pump-not-connected", "null_peripheral".toByteArray())
+        } else if (checkConnected && !pump.isConnected) {
+            Timber.e("pumpConnectedPrecondition: pump not connected")
+            callbacks.sendWearCommMessage("/from-pump/pump-not-connected", "not_connected".toByteArray())
+        } else {
+            return true
+        }
+        return false
+    }
+
+    private fun isBolusCommand(message: com.jwoglom.pumpx2.pump.messages.Message): Boolean {
+        return (message is InitiateBolusRequest) || (message.opCode() == InitiateBolusRequest().opCode() && message.characteristic == Characteristic.CONTROL)
+    }
+
+    override fun handleMessage(msg: Message) {
+        when (msg.what) {
+            CommServiceCodes.INIT_PUMP_COMM.ordinal -> {
+                if (pumpConnectedPrecondition(checkConnected = false)) {
+                    Timber.w("pumpCommHandler: init_pump_comm already run, ignoring")
+                    return
+                }
+                try {
+                    var pairingCodeType: PairingCodeType? = null
+                    var filterToBluetoothMac: String? = null
+                    if (msg.obj != null && msg.obj != "") {
+                        var parts = (msg.obj as String).split(" ")
+                        pairingCodeType = PairingCodeType.fromLabel(parts[0])
+                        if (parts.size == 2) {
+                            filterToBluetoothMac = parts[1]
+                        }
+                    }
+
+                    if (!ensurePumpUnbondedForFreshInit(filterToBluetoothMac)) {
+                        return
+                    }
+                    Timber.i("pumpCommHandler: init_pump_comm: msg.obj=${msg.obj as String} pairingCodeType=$pairingCodeType filterToBluetoothMac=$filterToBluetoothMac")
+                    val cfg = TandemConfig()
+                        .withFilterToBluetoothMac(filterToBluetoothMac)
+                        .withPairingCodeType(pairingCodeType)
+
+                    pump = Pump(cfg)
+                    tandemBTHandler =
+                        TandemBluetoothHandler.getInstance(callbacks.getApplicationContext(), pump, null)
+                } catch (e: SecurityException) {
+                    Timber.e("pumpCommHandler: SecurityException starting pump $e")
+                }
+                while (true) {
+                    try {
+                        Timber.i("pumpCommHandler: Starting scan...")
+                        tandemBTHandler.startScan()
+                        break
+                    } catch (e: SecurityException) {
+                        Timber.e("pumpCommHandler: Waiting for BT permissions $e")
+                        Thread.sleep(500)
+                    }
+                }
+            }
+            CommServiceCodes.STOP_PUMP_COMM.ordinal -> {
+                tandemBTHandler.stop()
+            }
+            CommServiceCodes.CHECK_PUMP_CONNECTED.ordinal -> {
+                if (pumpConnectedPrecondition()) {
+                    callbacks.sendWearCommMessage("/from-pump/pump-connected",
+                        pump.lastPeripheral?.name!!.toByteArray()
+                    )
+                }
+            }
+            CommServiceCodes.SEND_PUMP_PAIRING_MESSAGE.ordinal -> {
+                if (pumpConnectedPrecondition(checkConnected = false)) {
+                    if (pump.lastPeripheral != null && pump.pairingCodeCentralChallenge != null) {
+                        Timber.i("sendPumpPairingMessage: running performPairing")
+                        pump.performPairing(
+                            pump.lastPeripheral,
+                            pump.pairingCodeCentralChallenge,
+                            true
+                        )
+                    } else {
+                        Timber.w("sendPumpPairingMessage: cannot send pump pairing message: lastPeripheral=${pump.lastPeripheral} pairingCodeCentralChallenge=${pump.pairingCodeCentralChallenge}")
+                    }
+                }
+            }
+            CommServiceCodes.SEND_PUMP_COMMAND.ordinal -> {
+                Timber.i("pumpCommHandler send command raw: ${String(msg.obj as ByteArray)}")
+                val pumpMsg = PumpMessageSerializer.fromBytes(msg.obj as ByteArray)
+                if (isBolusCommand(pumpMsg)) {
+                    Timber.e("SEND_PUMP_COMMAND blocked bolus command")
+                } else if (pumpConnectedPrecondition()) {
+                    Timber.i("pumpCommHandler send command: $pumpMsg")
+                    pump.command(pumpMsg)
+                }
+            }
+            CommServiceCodes.SEND_PUMP_COMMANDS_BULK.ordinal -> {
+                Timber.i("pumpCommHandler send commands raw: ${String(msg.obj as ByteArray)}")
+                PumpMessageSerializer.fromBulkBytes(msg.obj as ByteArray).forEach {
+                    if (isBolusCommand(it)) {
+                        Timber.e("SEND_PUMP_COMMAND blocked bolus command")
+                    } else if (pumpConnectedPrecondition()) {
+                        Timber.i("pumpCommHandler send command: $it")
+                        pump.command(it)
+                    }
+                }
+            }
+            CommServiceCodes.SEND_PUMP_COMMANDS_BUST_CACHE_BULK.ordinal -> {
+                Timber.i("pumpCommHandler send commands bust cache raw: ${String(msg.obj as ByteArray)}")
+                PumpMessageSerializer.fromBulkBytes(msg.obj as ByteArray).forEach {
+                    if (callbacks.pumpCommState.lastResponseMessage.containsKey(Pair(it.characteristic, it.responseOpCode)) && !isBolusCommand(it)) {
+                        Timber.i("pumpCommHandler busted cache: $it")
+                        callbacks.pumpCommState.lastResponseMessage.remove(Pair(it.characteristic, it.responseOpCode))
+                    }
+                    if (isBolusCommand(it)) {
+                        Timber.e("SEND_PUMP_COMMAND blocked bolus command")
+                    } else if (pumpConnectedPrecondition()) {
+                        Timber.i("pumpCommHandler send command bust cache: $it")
+                        pump.command(it)
+                    }
+                }
+            }
+            CommServiceCodes.CACHED_PUMP_COMMANDS_BULK.ordinal -> {
+                Timber.i("pumpCommHandler cached pump commands raw: ${String(msg.obj as ByteArray)}")
+                PumpMessageSerializer.fromBulkBytes(msg.obj as ByteArray).forEach {
+                    if (callbacks.pumpCommState.lastResponseMessage.containsKey(Pair(it.characteristic, it.responseOpCode)) && !isBolusCommand(it)) {
+                        val response = callbacks.pumpCommState.lastResponseMessage.get(Pair(it.characteristic, it.responseOpCode))
+                        val ageSeconds = Duration.between(response?.second, Instant.now()).seconds
+                        if (ageSeconds <= CacheSeconds) {
+                            Timber.i("pumpCommHandler cached hit: $response")
+                            callbacks.sendWearCommMessage(
+                                "/from-pump/receive-cached-message",
+                                PumpMessageSerializer.toBytes(response?.first)
+                            )
+                        } else {
+                            Timber.i("pumpCommHandler expired cache hit $ageSeconds sec: $response")
+                            if (!isBolusCommand(it) && pumpConnectedPrecondition()) {
+                                pump.command(it)
+                            }
+                        }
+                    } else if (isBolusCommand(it)) {
+                        Timber.e("CACHED_PUMP_COMMANDS_BULK blocked bolus command")
+                    } else if (pumpConnectedPrecondition()) {
+                        Timber.i("pumpCommHandler cached miss: $it")
+                        pump.command(it)
+                    }
+                }
+            }
+            CommServiceCodes.SEND_PUMP_COMMAND_BOLUS.ordinal -> {
+                Timber.i("pumpCommHandler send bolus raw: ${String(msg.obj as ByteArray)}")
+                val secretKey = callbacks.getWearPrefs()?.getString("initiateBolusSecret", "") ?: ""
+                val confirmedBolus =
+                    InitiateConfirmedBolusSerializer.fromBytes(secretKey, msg.obj as ByteArray)
+
+                val messageOk = confirmedBolus.left
+                val pumpMsg = confirmedBolus.right
+                if (!messageOk) {
+                    Timber.w("pumpCommHandler bolus invalid signature")
+                    callbacks.sendWearCommMessage("/to-wear/bolus-blocked-signature", "WearCommHandler".toByteArray())
+                } else if (!isBolusCommand(pumpMsg)) {
+                    Timber.e("SEND_PUMP_COMMAND_BOLUS not a bolus command: $pumpMsg")
+                } else if (pumpConnectedPrecondition()) {
+                    Timber.i("pumpCommHandler send bolus command with valid signature: $pumpMsg")
+                    if (!Prefs(callbacks.getApplicationContext()).insulinDeliveryActions()) {
+                        Timber.e("No insulin delivery messages enabled -- blocking bolus command $pumpMsg")
+                        callbacks.sendWearCommMessage("/to-wear/bolus-not-enabled", "from_self".toByteArray())
+                        return
+                    }
+                    try {
+                        pump.command(pumpMsg as InitiateBolusRequest)
+                    } catch (e: Packetize.ActionsAffectingInsulinDeliveryNotEnabledInPumpX2Exception) {
+                        Timber.e(e)
+                        callbacks.sendWearCommMessage("/to-wear/bolus-not-enabled", "from_pumpx2_lib".toByteArray())
+                    }
+                }
+            }
+            CommServiceCodes.DEBUG_WRITE_BT_CHARACTERISTIC.ordinal -> {
+                Timber.i("pumpCommHandler debug_write_bt_characteristic: ${String(msg.obj as ByteArray)}")
+                try {
+                    val contents = JSONObject(String(msg.obj as ByteArray));
+                    val uuidStr = contents.getString("characteristicUuid")
+                    val uuid = UUID.fromString(uuidStr)
+
+                    val valuesStr = contents.getJSONArray("valuesHex")
+                    var valuesHex = ArrayList<ByteArray>()
+                    for (i in 0..valuesStr.length()) {
+                        valuesHex.add(Hex.decodeHex(valuesStr.getString(i)))
+                    }
+
+                    if (pumpConnectedPrecondition()) {
+                        if (!Prefs(callbacks.getApplicationContext()).insulinDeliveryActions()) {
+                            return
+                        }
+                        valuesHex.forEach {
+                            Packetize.txId.increment()
+                            pump.lastPeripheral?.writeCharacteristic(
+                                ServiceUUID.PUMP_SERVICE_UUID,
+                                uuid,
+                                it,
+                                WriteType.WITH_RESPONSE
+                            )
+                        }
+                    }
+                } catch (e: Exception) {
+                    Timber.e(e)
+                }
+            }
+            CommServiceCodes.WRITE_CHARACTERISTIC_FAILED_CALLBACK.ordinal -> {
+                val uuidStr = msg.obj as String
+                if (pumpConnectedPrecondition(checkConnected = false)) {
+                    if (uuidStr == "${CharacteristicUUID.AUTHORIZATION_CHARACTERISTICS}") {
+                        Timber.w("writeCharacteristicFailedCallback: calling onPumpConnected pump=$pump from authorization error")
+                        pump.onPumpConnected(pump.lastPeripheral)
+                    } else {
+                        Timber.w("writeCharacteristicFailedCallback: triggering disconnection from non-authorization error")
+                        pump.lastPeripheral?.cancelConnection();
+                        pump.lastPeripheral?.let { pump.onPumpDisconnected(it, null) }
+                    }
+                }
+            }
+            CommServiceCodes.DEBUG_GET_MESSAGE_CACHE.ordinal -> {
+                Timber.i("pumpCommHandler debug get message cache: ${callbacks.pumpCommState}.lastResponseMessage")
+                callbacks.sendWearCommMessage("/from-pump/debug-message-cache", PumpMessageSerializer.toDebugMessageCacheBytes(callbacks.pumpCommState.lastResponseMessage.values))
+            }
+            CommServiceCodes.DEBUG_GET_HISTORYLOG_CACHE.ordinal -> {
+                Timber.i("pumpCommHandler debug get historylog cache: ${callbacks.pumpCommState}.historyLogCache")
+                if (callbacks.pumpCommState.historyLogCache.size <= 100) {
+                    callbacks.sendWearCommMessage(
+                        "/from-pump/debug-historylog-cache",
+                        PumpMessageSerializer.toDebugHistoryLogCacheBytes(callbacks.pumpCommState.historyLogCache)
+                    )
+                } else {
+                    callbacks.pumpCommState.historyLogCache.entries.toList().chunked(100).forEach {
+                        callbacks.sendWearCommMessage(
+                            "/from-pump/debug-historylog-cache",
+                            PumpMessageSerializer.toDebugHistoryLogCacheBytes(it.associate {
+                                Pair(it.key, it.value)
+                            })
+                        )
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Refactored the `PumpCommHandler` inner class out of `CommService` into a standalone top-level class in a new file. This improves code organization, testability, and maintainability by separating pump communication logic from the service lifecycle.

## Key Changes

- **Extracted `PumpCommHandler`**: Moved the inner class from `CommService.kt` to a new file `pump/PumpCommHandler.kt` as a standalone class that takes a `CommServiceCallbacks` interface for dependency injection
- **Created `CommServiceCallbacks` interface**: Defined a contract for callbacks that `PumpCommHandler` needs from `CommService`, including:
  - Application context access
  - Wear communication message sending
  - Pump state and history log repository access
  - Toast and notification display
  - HTTP debug API service access
  - Supervisor job for coroutine scope management
- **Created `BleChangeReceiver`**: Extracted Bluetooth state change handling into a dedicated `BroadcastReceiver` class with `BondState` enum for cleaner separation of concerns
- **Updated `CommService`**: Modified to implement `CommServiceCallbacks` and instantiate `PumpCommHandler` with the callback interface
- **Removed unused imports**: Cleaned up numerous unused imports from `CommService.kt` that are now only needed in `PumpCommHandler.kt`

## Implementation Details

- The `PumpCommHandler` now receives a `Looper` and `CommServiceCallbacks` in its constructor, making it independent of `CommService`
- All references to `this@CommService` in the original inner class are now replaced with `callbacks` method calls
- The `Pump` inner class remains nested within `PumpCommHandler` as it's tightly coupled to the handler's lifecycle
- History log fetcher and sync worker management is now encapsulated within `PumpCommHandler`
- The constant `CacheSeconds` was moved to the new `PumpCommHandler.kt` file where it's used

https://claude.ai/code/session_01UoJVzuZCwtXo828Rc5n7mP