### PR TITLE
Add Robolectric JAR download step to Android CI workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -35,6 +35,12 @@ jobs:
           echo $ENCODED_STRING | base64 -di > release.keystore
 
 
+      - name: Download Robolectric jars
+        run: |
+          mkdir -p ~/.robolectric
+          curl -L -o ~/.robolectric/android-all-instrumented-14-robolectric-10818077-i7.jar \
+            https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/14-robolectric-10818077-i7/android-all-instrumented-14-robolectric-10818077-i7.jar
+
       - name: Assemble Release
         run: |
           ./gradlew build assembleRelease \


### PR DESCRIPTION
## Summary
Added a pre-build step to the Android CI workflow that downloads the Robolectric instrumented Android JAR file before assembling the release build.

## Key Changes
- Added a new "Download Robolectric jars" step in the Android workflow that:
  - Creates the `~/.robolectric` directory if it doesn't exist
  - Downloads the `android-all-instrumented-14-robolectric-10818077-i7.jar` from Maven Central Repository
  - Executes before the "Assemble Release" step

## Details
This change ensures that Robolectric dependencies are available in the CI environment during the build process. The JAR is downloaded from the official Maven Central Repository to the standard Robolectric cache directory, allowing the build to access the instrumented Android framework needed for unit testing with Robolectric.

https://claude.ai/code/session_019y7uBm8ZF8f7QkHjRv9Nog