### PR TITLE
Clear bolus calculation state on refresh and reset

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/BolusWindow.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/BolusWindow.kt
@@ -144,6 +144,7 @@ fun BolusWindow(
     fun refresh() = refreshScope.launch {
         refreshing = true
 
+        baseFields.forEach { field -> field.value = null }
         sendPumpCommands(SendType.BUST_CACHE, commands)
     }
 
@@ -552,6 +553,8 @@ fun rawToInt(s: String?): Int? {
 fun resetBolusDataStoreState(dataStore: DataStore) {
     Timber.d("bolusCalc resetBolusDataStoreState")
     PumpStateSupplier.inProgressBolusId = Supplier { null }
+    dataStore.bolusCalcDataSnapshot.value = null
+    dataStore.bolusCalcLastBG.value = null
     dataStore.bolusPermissionResponse.value = null
     dataStore.bolusCancelResponse.value = null
     dataStore.bolusInitiateResponse.value = null

--- a/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/BolusScreen.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/BolusScreen.kt
@@ -536,6 +536,8 @@ fun BolusScreen(
 
 
 fun resetBolusDataStoreState(dataStore: DataStore) {
+    dataStore.bolusCalcDataSnapshot.value = null
+    dataStore.bolusCalcLastBG.value = null
     dataStore.bolusPermissionResponse.value = null
     dataStore.bolusCancelResponse.value = null
     dataStore.bolusInitiateResponse.value = null


### PR DESCRIPTION
## Summary
This PR ensures that bolus calculation data is properly cleared when refreshing or resetting the bolus state, preventing stale data from persisting across operations.

## Key Changes
- **BolusWindow.kt**: Clear all base fields when refreshing to ensure fresh state
- **resetBolusDataStoreState()**: Added clearing of `bolusCalcDataSnapshot` and `bolusCalcLastBG` fields in both mobile and wear implementations
  - Mobile: Updated in `mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/BolusWindow.kt`
  - Wear: Updated in `wear/src/main/java/com/jwoglom/controlx2/presentation/ui/BolusScreen.kt`

## Implementation Details
The changes ensure that when bolus operations are reset or refreshed, all related calculation data is cleared from the DataStore, preventing potential issues with stale values being used in subsequent bolus calculations. This includes both the data snapshot and last blood glucose reading used for calculations.

https://claude.ai/code/session_01C6dnLHPWN3LXxcFuodhJdN