### PR TITLE
Add basal rate treatment broadcasts to xDrip integration

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/xdrip/XdripMessageDispatcher.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/xdrip/XdripMessageDispatcher.kt
@@ -23,6 +23,7 @@ internal sealed class DispatchEvent {
     data class PumpIob(val units: Double) : DispatchEvent()
     data class PumpReservoir(val units: Int) : DispatchEvent()
     data class PumpBasal(val unitsPerHour: Double) : DispatchEvent()
+    data class BasalTreatment(val unitsPerHour: Double) : DispatchEvent()
     data class CgmSgv(val mgdl: Int, val trendRate: Int) : DispatchEvent()
     data class TreatmentInitiated(val bolusId: Int, val status: String) : DispatchEvent()
     data class TreatmentStatus(val bolusId: Int, val requestedVolumeMilli: Long, val status: String, val timestamp: Instant) : DispatchEvent()
@@ -50,7 +51,7 @@ class XdripMessageDispatcher(
         if (!config.enabled) return
 
         val receivedAt = nowProvider()
-        val category = updateSnapshot(event, receivedAt)
+        val categories = updateSnapshot(event, receivedAt)
 
         if (config.sendCgmSgv && event is DispatchEvent.CgmSgv) {
             val sgvPayload = XdripSgvPayload
@@ -59,14 +60,14 @@ class XdripMessageDispatcher(
             broadcaster.sendSgv(sgvPayload, config.cgmSgvMinimumIntervalSeconds)
         }
 
-        if (config.sendPumpDeviceStatus && category == StatusCategory.PUMP_STATUS) {
+        if (config.sendPumpDeviceStatus && StatusCategory.PUMP_STATUS in categories) {
             val deviceStatusPayload = latestPumpSnapshot
                 .toPayload(createdAt = receivedAt)
                 .toJsonString()
             broadcaster.sendDeviceStatus(deviceStatusPayload, config.pumpDeviceStatusMinimumIntervalSeconds)
         }
 
-        if (config.sendTreatments && category == StatusCategory.TREATMENT) {
+        if (config.sendTreatments && StatusCategory.TREATMENT in categories) {
             val treatmentPayload = when (event) {
                 is DispatchEvent.TreatmentInitiated -> XdripTreatmentPayload(
                     eventType = "Bolus",
@@ -84,6 +85,14 @@ class XdripMessageDispatcher(
                     )
                     .toJsonArrayString()
 
+                is DispatchEvent.BasalTreatment -> XdripTreatmentPayload
+                    .forBasalRate(
+                        unitsPerHour = event.unitsPerHour,
+                        durationMinutes = BASAL_TREATMENT_DURATION_MINUTES,
+                        timestamp = receivedAt
+                    )
+                    .toJsonArrayString()
+
                 else -> null
             }
             if (treatmentPayload != null) {
@@ -95,7 +104,7 @@ class XdripMessageDispatcher(
             }
         }
 
-        if (config.sendStatusLine && category == StatusCategory.PUMP_STATUS) {
+        if (config.sendStatusLine && StatusCategory.PUMP_STATUS in categories) {
             val statusline = buildString {
                 append("Pump")
                 latestPumpSnapshot.sgvMgdl?.value?.let { append(" SGV:$it") }
@@ -108,31 +117,35 @@ class XdripMessageDispatcher(
         }
     }
 
-    private fun updateSnapshot(event: DispatchEvent, receivedAt: Instant): StatusCategory {
+    private fun updateSnapshot(event: DispatchEvent, receivedAt: Instant): Set<StatusCategory> {
         return when (event) {
             is DispatchEvent.PumpBattery -> {
                 latestPumpSnapshot.batteryPercent = XdripTimedValue(event.percent, receivedAt)
-                StatusCategory.PUMP_STATUS
+                setOf(StatusCategory.PUMP_STATUS)
             }
             is DispatchEvent.PumpIob -> {
                 latestPumpSnapshot.iobUnits = XdripTimedValue(event.units, receivedAt)
-                StatusCategory.PUMP_STATUS
+                setOf(StatusCategory.PUMP_STATUS)
             }
             is DispatchEvent.PumpReservoir -> {
                 latestPumpSnapshot.cartridgeUnits = XdripTimedValue(event.units, receivedAt)
-                StatusCategory.PUMP_STATUS
+                setOf(StatusCategory.PUMP_STATUS)
             }
             is DispatchEvent.PumpBasal -> {
                 latestPumpSnapshot.basalUnitsPerHour = XdripTimedValue(event.unitsPerHour, receivedAt)
-                StatusCategory.PUMP_STATUS
+                setOf(StatusCategory.PUMP_STATUS)
+            }
+            is DispatchEvent.BasalTreatment -> {
+                latestPumpSnapshot.basalUnitsPerHour = XdripTimedValue(event.unitsPerHour, receivedAt)
+                setOf(StatusCategory.PUMP_STATUS, StatusCategory.TREATMENT)
             }
             is DispatchEvent.CgmSgv -> {
                 latestPumpSnapshot.applySgvValue(event.mgdl, receivedAt)
-                StatusCategory.PUMP_STATUS
+                setOf(StatusCategory.PUMP_STATUS)
             }
             is DispatchEvent.TreatmentInitiated,
-            is DispatchEvent.TreatmentStatus -> StatusCategory.TREATMENT
-            is DispatchEvent.Other -> StatusCategory.OTHER
+            is DispatchEvent.TreatmentStatus -> setOf(StatusCategory.TREATMENT)
+            is DispatchEvent.Other -> setOf(StatusCategory.OTHER)
         }
     }
 
@@ -141,7 +154,7 @@ class XdripMessageDispatcher(
             is CurrentBatteryAbstractResponse -> DispatchEvent.PumpBattery(batteryPercent)
             is ControlIQIOBResponse -> DispatchEvent.PumpIob(InsulinUnit.from1000To1(pumpDisplayedIOB))
             is InsulinStatusResponse -> DispatchEvent.PumpReservoir(currentInsulinAmount)
-            is CurrentBasalStatusResponse -> DispatchEvent.PumpBasal(InsulinUnit.from1000To1(currentBasalRate))
+            is CurrentBasalStatusResponse -> DispatchEvent.BasalTreatment(InsulinUnit.from1000To1(currentBasalRate))
             is CurrentEGVGuiDataResponse -> DispatchEvent.CgmSgv(cgmReading, trendRate)
             is InitiateBolusResponse -> DispatchEvent.TreatmentInitiated(bolusId, statusType.toString())
             is CurrentBolusStatusResponse -> DispatchEvent.TreatmentStatus(
@@ -158,5 +171,10 @@ class XdripMessageDispatcher(
         PUMP_STATUS,
         TREATMENT,
         OTHER
+    }
+
+    companion object {
+        /** Duration for basal treatment segments, matching the pump status polling interval. */
+        internal const val BASAL_TREATMENT_DURATION_MINUTES = 5
     }
 }

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/xdrip/models/XdripTreatmentPayload.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/xdrip/models/XdripTreatmentPayload.kt
@@ -12,6 +12,9 @@ data class XdripTreatmentPayload(
     val createdAt: String,
     val mills: Long,
     val insulin: Double? = null,
+    val duration: Int? = null,
+    val rate: Double? = null,
+    val absolute: Double? = null,
     val notes: String
 ) {
     fun toJsonObject(): JSONObject {
@@ -20,6 +23,9 @@ data class XdripTreatmentPayload(
             put("created_at", createdAt)
             put("mills", mills)
             insulin?.let { put("insulin", it) }
+            duration?.let { put("duration", it) }
+            rate?.let { put("rate", it) }
+            absolute?.let { put("absolute", it) }
             put("notes", notes)
         }
     }
@@ -60,6 +66,22 @@ data class XdripTreatmentPayload(
                 mills = timestamp.toEpochMilli(),
                 insulin = InsulinUnit.from1000To1(requestedVolumeMilli),
                 notes = "ControlX2 bolus status bolusId=$bolusId status=$status"
+            )
+        }
+
+        fun forBasalRate(
+            unitsPerHour: Double,
+            durationMinutes: Int,
+            timestamp: Instant
+        ): XdripTreatmentPayload {
+            return XdripTreatmentPayload(
+                eventType = "Temp Basal",
+                createdAt = timestamp.toString(),
+                mills = timestamp.toEpochMilli(),
+                duration = durationMinutes,
+                rate = unitsPerHour,
+                absolute = unitsPerHour,
+                notes = "ControlX2 basal rate ${unitsPerHour}U/h"
             )
         }
     }

--- a/mobile/src/test/java/com/jwoglom/controlx2/sync/xdrip/XdripBroadcastIntegrationTest.kt
+++ b/mobile/src/test/java/com/jwoglom/controlx2/sync/xdrip/XdripBroadcastIntegrationTest.kt
@@ -219,6 +219,69 @@ class XdripBroadcastIntegrationTest {
     }
 
     // ---------------------------------------------------------------
+    // 2b. Basal treatment broadcast — xDrip draws basal bar/graph
+    // ---------------------------------------------------------------
+
+    @Test
+    fun fullPipeline_basalTreatmentBroadcast_matchesXdripSchema() {
+        config = config.copy(sendCgmSgv = false, sendPumpDeviceStatus = false, sendStatusLine = false)
+        dispatcher.onReceiveMessage(CurrentBasalStatusResponse(0, 900, 0))
+
+        val treatmentBroadcasts = broadcastsWithAction(XdripBroadcastSender.ACTION_NEW_TREATMENT)
+        assertEquals("one treatment broadcast for basal", 1, treatmentBroadcasts.size)
+
+        val bc = treatmentBroadcasts.single()
+        assertEquals("treatments", bc.extraKey)
+
+        val arr = JSONArray(bc.payload)
+        assertTrue("payload must be non-empty array", arr.length() > 0)
+        val trtMap = jsonToMap(arr.getJSONObject(0).toString())
+
+        // mills must exist and be positive
+        val mills = trtMap["mills"] ?: trtMap["date"]
+        assertNotNull("mills/date required for xDrip treatment timestamp", mills)
+        assertTrue("timestamp > 0", (mills as Number).toLong() > 0)
+
+        // eventType must be "Temp Basal" for xDrip to render basal bars
+        assertNotNull("eventType required", trtMap["eventType"])
+        assertEquals("Temp Basal", trtMap["eventType"].toString())
+
+        // duration must be present and positive for xDrip to draw basal segment
+        assertNotNull("duration required for basal segment rendering", trtMap["duration"])
+        assertTrue("duration > 0", (trtMap["duration"] as Number).toInt() > 0)
+
+        // rate and absolute must be present for xDrip basal rate display
+        assertNotNull("rate required for basal treatment", trtMap["rate"])
+        assertTrue("rate > 0", (trtMap["rate"] as Number).toDouble() > 0)
+        assertNotNull("absolute required for basal treatment", trtMap["absolute"])
+        assertTrue("absolute > 0", (trtMap["absolute"] as Number).toDouble() > 0)
+
+        // created_at should be an ISO string
+        assertNotNull("created_at expected", trtMap["created_at"])
+
+        // Food broadcast should also be sent
+        val foodBroadcasts = broadcastsWithAction(XdripBroadcastSender.ACTION_NEW_FOOD)
+        assertEquals("one food broadcast for basal", 1, foodBroadcasts.size)
+    }
+
+    @Test
+    fun fullPipeline_basalTreatmentBroadcast_alsoTriggersDeviceStatus() {
+        config = config.copy(sendCgmSgv = false, sendStatusLine = false)
+        dispatcher.onReceiveMessage(CurrentBasalStatusResponse(0, 850, 0))
+
+        // Basal should trigger BOTH treatment and device status
+        val treatmentBroadcasts = broadcastsWithAction(XdripBroadcastSender.ACTION_NEW_TREATMENT)
+        val dsBroadcasts = broadcastsWithAction(XdripBroadcastSender.ACTION_NEW_DEVICE_STATUS)
+        assertEquals("one treatment broadcast", 1, treatmentBroadcasts.size)
+        assertEquals("one device status broadcast", 1, dsBroadcasts.size)
+
+        // Verify device status has the basal value
+        val dsObj = JSONObject(dsBroadcasts.single().payload)
+        assertTrue("device status has pump object", dsObj.has("pump"))
+        assertTrue("pump has basal field", dsObj.getJSONObject("pump").has("basal"))
+    }
+
+    // ---------------------------------------------------------------
     // 3. Device status broadcast — xDrip AAPSStatusHandler / NSDeviceStatus
     // ---------------------------------------------------------------
 

--- a/mobile/src/test/java/com/jwoglom/controlx2/sync/xdrip/XdripMessageDispatcherTest.kt
+++ b/mobile/src/test/java/com/jwoglom/controlx2/sync/xdrip/XdripMessageDispatcherTest.kt
@@ -11,6 +11,7 @@ import com.jwoglom.pumpx2.pump.messages.response.currentStatus.InsulinStatusResp
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.time.Instant
@@ -155,6 +156,41 @@ class XdripMessageDispatcherTest {
         assertEquals(InsulinUnit.from1000To1(2300), status.getDouble("insulin"), 0.0001)
         assertTrue(status.getLong("mills") > 0)
         assertTrue(status.getString("notes").contains("status="))
+    }
+
+    @Test
+    fun onReceiveMessage_mapsBasalStatusToTreatmentAndDeviceStatus() {
+        val broadcaster = FakeBroadcaster()
+        val now = Instant.parse("2026-01-01T00:00:00Z")
+        val dispatcher = XdripMessageDispatcher(
+            broadcaster = broadcaster,
+            configProvider = {
+                XdripSyncConfig(
+                    enabled = true,
+                    sendCgmSgv = false,
+                    sendStatusLine = false
+                )
+            },
+            nowProvider = { now }
+        )
+
+        dispatcher.onReceiveMessage(CurrentBasalStatusResponse(0, 900, 0))
+
+        // Should trigger both device status and treatment broadcasts
+        assertEquals(1, broadcaster.deviceStatusPayloads.size)
+        assertEquals(1, broadcaster.treatmentPayloads.size)
+
+        // Verify treatment payload has basal fields
+        val treatment = JSONArray(broadcaster.treatmentPayloads.single().payload).getJSONObject(0)
+        assertEquals("Temp Basal", treatment.getString("eventType"))
+        assertEquals(InsulinUnit.from1000To1(900), treatment.getDouble("rate"), 0.0001)
+        assertEquals(InsulinUnit.from1000To1(900), treatment.getDouble("absolute"), 0.0001)
+        assertEquals(XdripMessageDispatcher.BASAL_TREATMENT_DURATION_MINUTES, treatment.getInt("duration"))
+        assertEquals(now.toEpochMilli(), treatment.getLong("mills"))
+
+        // Verify device status also updated
+        val deviceStatus = JSONObject(broadcaster.deviceStatusPayloads.single().payload)
+        assertEquals(InsulinUnit.from1000To1(900), deviceStatus.getJSONObject("pump").getDouble("basal"), 0.0001)
     }
 
     @Test

--- a/mobile/src/test/java/com/jwoglom/controlx2/sync/xdrip/XdripPayloadModelsTest.kt
+++ b/mobile/src/test/java/com/jwoglom/controlx2/sync/xdrip/XdripPayloadModelsTest.kt
@@ -101,4 +101,23 @@ class XdripPayloadModelsTest {
         assertTrue(statusObj.getLong("mills") > 0)
         assertTrue(statusObj.getString("notes").contains("bolusId=77"))
     }
+
+    @Test
+    fun treatmentPayload_forBasalRate_includesBasalFields() {
+        val timestamp = Instant.parse("2026-01-01T00:00:00Z")
+        val payload = XdripTreatmentPayload
+            .forBasalRate(unitsPerHour = 0.85, durationMinutes = 5, timestamp = timestamp)
+            .toJsonArrayString()
+        val obj = JSONArray(payload).getJSONObject(0)
+
+        assertEquals("Temp Basal", obj.getString("eventType"))
+        assertEquals(timestamp.toEpochMilli(), obj.getLong("mills"))
+        assertEquals(timestamp.toString(), obj.getString("created_at"))
+        assertEquals(5, obj.getInt("duration"))
+        assertEquals(0.85, obj.getDouble("rate"), 0.0001)
+        assertEquals(0.85, obj.getDouble("absolute"), 0.0001)
+        assertTrue(obj.getString("notes").contains("0.85U/h"))
+        // Basal treatments should not have insulin field
+        assertTrue(!obj.has("insulin"))
+    }
 }


### PR DESCRIPTION
## Summary
This change extends the xDrip integration to broadcast basal rate information as treatment events, allowing xDrip to render basal rate bars/graphs in addition to updating device status.

## Key Changes
- **New DispatchEvent type**: Added `BasalTreatment` event to distinguish basal rate broadcasts from general pump status updates
- **Dual broadcast support**: Basal rate changes now trigger both treatment and device status broadcasts, enabling xDrip's basal visualization
- **Treatment payload enhancement**: Extended `XdripTreatmentPayload` with basal-specific fields (`duration`, `rate`, `absolute`) and added `forBasalRate()` factory method
- **Event categorization**: Changed `updateSnapshot()` to return a `Set<StatusCategory>` instead of a single category, allowing events to trigger multiple broadcast types
- **Message mapping**: Updated `CurrentBasalStatusResponse` mapping to emit `BasalTreatment` events instead of `PumpBasal` events
- **Standardized duration**: Basal treatment segments use a 5-minute duration matching the pump status polling interval

## Implementation Details
- Basal treatments are formatted as "Temp Basal" events with rate and absolute fields set to the current basal rate
- The change maintains backward compatibility by still updating the pump snapshot's basal value for device status broadcasts
- All changes are covered by comprehensive unit and integration tests verifying the broadcast payloads match xDrip's expected schema

https://claude.ai/code/session_01FpY5gCbFq9FexantEqyuPm