### PR TITLE
Refactor pump time handling to use epoch seconds

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/HttpDebugApiService.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/HttpDebugApiService.kt
@@ -550,8 +550,8 @@ class HttpDebugApiService(private val context: Context, private val port: Int = 
                 json.put("totalCount", count)
                 json.put("oldestSeqId", oldest?.seqId)
                 json.put("newestSeqId", latest?.seqId)
-                json.put("oldestPumpTime", oldest?.pumpTime?.toString())
-                json.put("newestPumpTime", latest?.pumpTime?.toString())
+                json.put("oldestPumpTime", oldest?.pumpTimeLocal()?.toString())
+                json.put("newestPumpTime", latest?.pumpTimeLocal()?.toString())
                 json.put("oldestAddedTime", oldest?.addedTime?.toString())
                 json.put("newestAddedTime", latest?.addedTime?.toString())
 
@@ -580,7 +580,13 @@ class HttpDebugApiService(private val context: Context, private val port: Int = 
                     obj.put("typeName", typeNameFromTypeId(stat.typeId))
                     obj.put("count", stat.count)
                     obj.put("latestSeqId", stat.latestSeqId)
-                    obj.put("latestPumpTime", stat.latestPumpTime?.toString())
+                    obj.put("latestPumpTimeSec", stat.latestPumpTimeSec)
+                    obj.put("latestPumpTime", stat.latestPumpTimeSec?.let {
+                        java.time.LocalDateTime.ofEpochSecond(
+                            it + com.jwoglom.pumpx2.pump.messages.helpers.Dates.JANUARY_1_2008_UNIX_EPOCH,
+                            0, java.time.ZoneOffset.UTC
+                        ).toString()
+                    })
                     typeStatsArray.put(obj)
                 }
 
@@ -773,8 +779,8 @@ class HttpDebugApiService(private val context: Context, private val port: Int = 
 
         private fun filterByTimeRange(items: List<HistoryLogItem>, min: LocalDateTime?, max: LocalDateTime?): List<HistoryLogItem> {
             return items.filter { item ->
-                val afterMin = min?.let { item.pumpTime >= it } ?: true
-                val beforeMax = max?.let { item.pumpTime <= it } ?: true
+                val afterMin = min?.let { item.pumpTimeLocal() >= it } ?: true
+                val beforeMax = max?.let { item.pumpTimeLocal() <= it } ?: true
                 afterMin && beforeMax
             }
         }
@@ -1012,7 +1018,8 @@ class HttpDebugApiService(private val context: Context, private val port: Int = 
         json.put("pumpSid", item.pumpSid)
         json.put("typeId", item.typeId)
         json.put("cargoHex", item.cargo.joinToString("") { "%02x".format(it) })
-        json.put("pumpTime", item.pumpTime.toString())
+        json.put("pumpTime", item.pumpTimeLocal().toString())
+        json.put("pumpTimeSec", item.pumpTimeSec)
         json.put("addedTime", item.addedTime.toString())
 
         if (format == "parsed") {

--- a/mobile/src/main/java/com/jwoglom/controlx2/db/historylog/HistoryLogDao.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/db/historylog/HistoryLogDao.kt
@@ -5,13 +5,12 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import kotlinx.coroutines.flow.Flow
-import java.time.LocalDateTime
 
 data class HistoryLogTypeStats(
     val typeId: Int,
     val count: Long,
     val latestSeqId: Long?,
-    val latestPumpTime: LocalDateTime?
+    val latestPumpTimeSec: Long?
 )
 
 @Dao
@@ -119,7 +118,7 @@ interface HistoryLogDao {
     fun getLatestForType(pumpSid: Int, typeId: Int): Flow<HistoryLogItem?>
 
     @Query("""
-        SELECT typeId AS typeId, COUNT(*) AS count, MAX(seqId) AS latestSeqId, MAX(pumpTime) AS latestPumpTime
+        SELECT typeId AS typeId, COUNT(*) AS count, MAX(seqId) AS latestSeqId, MAX(pumpTimeSec) AS latestPumpTimeSec
         FROM $HistoryLogTable
         WHERE pumpSid = :pumpSid
         GROUP BY typeId

--- a/mobile/src/main/java/com/jwoglom/controlx2/db/historylog/HistoryLogDummyDao.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/db/historylog/HistoryLogDummyDao.kt
@@ -89,7 +89,7 @@ class HistoryLogDummyDao(val data: MutableList<HistoryLogItem>) : HistoryLogDao 
                     typeId = typeId,
                     count = items.size.toLong(),
                     latestSeqId = items.maxOfOrNull { it.seqId },
-                    latestPumpTime = items.maxOfOrNull { it.pumpTime }
+                    latestPumpTimeSec = items.maxOfOrNull { it.pumpTimeSec }
                 )
             }
     }

--- a/mobile/src/main/java/com/jwoglom/controlx2/db/historylog/HistoryLogItem.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/db/historylog/HistoryLogItem.kt
@@ -5,8 +5,10 @@ import androidx.room.Entity
 import androidx.room.Ignore
 import com.jwoglom.pumpx2.pump.messages.response.historyLog.HistoryLog
 import com.jwoglom.pumpx2.pump.messages.response.historyLog.HistoryLogParser
+import com.jwoglom.pumpx2.pump.messages.helpers.Dates
 import java.time.LocalDateTime
 import java.time.ZoneId
+import java.time.ZoneOffset
 
 val itemLruCache = LruCache<Pair<Long, Int>, HistoryLog>(500)
 
@@ -38,6 +40,16 @@ class HistoryLogItem(
         pumpTime=LocalDateTime.ofInstant(message.pumpTimeSecInstant, ZoneId.systemDefault()),
         addedTime=addedTime
     )
+
+    /**
+     * Derive local wall-clock time from [pumpTimeSec].
+     * Use this instead of the deprecated [pumpTime] field.
+     */
+    @Ignore
+    fun pumpTimeLocal(): LocalDateTime =
+        LocalDateTime.ofEpochSecond(
+            pumpTimeSec + Dates.JANUARY_1_2008_UNIX_EPOCH, 0, ZoneOffset.UTC
+        )
 
     @Ignore
     fun parse(): HistoryLog {

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/VicoCgmChart.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/VicoCgmChart.kt
@@ -747,7 +747,7 @@ private fun rememberBasalData(
             } catch (e: Exception) {
                 rawEntries += BasalHistoryDebugEntry(
                     seqId = dao.seqId,
-                    timestamp = dao.pumpTime.atZone(ZoneId.systemDefault()).toEpochSecond(),
+                    timestamp = dao.pumpTimeLocal().atZone(ZoneId.systemDefault()).toEpochSecond(),
                     details = "parseFailure=${e.javaClass.simpleName}:${e.message ?: ""}"
                 )
                 parseFailureCount++

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/NightscoutSyncCoordinator.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/NightscoutSyncCoordinator.kt
@@ -236,7 +236,7 @@ class NightscoutSyncCoordinator(
         // Case 3: First-time sync - use lookbackHours
         val lookbackTime = LocalDateTime.now().minusHours(syncState.lookbackHours.toLong())
         val logs = historyLogRepo.getAll(pumpSid).first()
-        val startSeqId = logs.firstOrNull { it.pumpTime >= lookbackTime }?.seqId ?: 0L
+        val startSeqId = logs.firstOrNull { it.pumpTimeLocal() >= lookbackTime }?.seqId ?: 0L
 
         val latestLog = historyLogRepo.getLatest(pumpSid).first()
         val endSeqId = latestLog?.seqId ?: Long.MAX_VALUE
@@ -254,8 +254,8 @@ class NightscoutSyncCoordinator(
     ): Pair<Long, Long> {
         val logs = historyLogRepo.getAll(pumpSid).first()
 
-        val startSeqId = logs.firstOrNull { it.pumpTime >= startTime }?.seqId ?: 0L
-        val endSeqId = logs.lastOrNull { it.pumpTime <= endTime }?.seqId ?: Long.MAX_VALUE
+        val startSeqId = logs.firstOrNull { it.pumpTimeLocal() >= startTime }?.seqId ?: 0L
+        val endSeqId = logs.lastOrNull { it.pumpTimeLocal() <= endTime }?.seqId ?: Long.MAX_VALUE
 
         Timber.d("Retroactive sync range: seqId $startSeqId..$endSeqId for time $startTime..$endTime")
         return startSeqId to endSeqId

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/processors/ProcessAlarm.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/processors/ProcessAlarm.kt
@@ -79,7 +79,7 @@ class ProcessAlarm(
 
                 NightscoutTreatment.fromTimestamp(
                     eventType = "Announcement",
-                    timestamp = item.pumpTime,
+                    timestamp = item.pumpTimeLocal(),
                     seqId = item.seqId,
                     reason = reason,
                     notes = "Pump alarm activated, ID: ${parsed.alarmId}"
@@ -95,7 +95,7 @@ class ProcessAlarm(
 
                 NightscoutTreatment.fromTimestamp(
                     eventType = "Announcement",
-                    timestamp = item.pumpTime,
+                    timestamp = item.pumpTimeLocal(),
                     seqId = item.seqId,
                     reason = reason,
                     notes = "Pump alarm cleared, ID: ${parsed.alarmId}"
@@ -111,7 +111,7 @@ class ProcessAlarm(
 
                 NightscoutTreatment.fromTimestamp(
                     eventType = "Announcement",
-                    timestamp = item.pumpTime,
+                    timestamp = item.pumpTimeLocal(),
                     seqId = item.seqId,
                     reason = reason,
                     notes = "Pump alert activated, ID: ${parsed.alertId}"
@@ -127,7 +127,7 @@ class ProcessAlarm(
 
                 NightscoutTreatment.fromTimestamp(
                     eventType = "Announcement",
-                    timestamp = item.pumpTime,
+                    timestamp = item.pumpTimeLocal(),
                     seqId = item.seqId,
                     reason = reason,
                     notes = "Pump alert cleared, ID: ${parsed.alertId}"

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/processors/ProcessBasal.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/processors/ProcessBasal.kt
@@ -92,7 +92,7 @@ class ProcessBasal(
 
             treatments.add(NightscoutTreatment.fromTimestamp(
                 eventType = "Temp Basal",
-                timestamp = item.pumpTime,
+                timestamp = item.pumpTimeLocal(),
                 seqId = item.seqId,
                 rate = null,
                 absolute = null,
@@ -103,11 +103,11 @@ class ProcessBasal(
         }
 
         // Process BasalDelivery and BasalRateChange logs with calculated durations
-        val sortedOther = otherLogs.sortedBy { it.pumpTime }
+        val sortedOther = otherLogs.sortedBy { it.pumpTimeLocal() }
         for (i in sortedOther.indices) {
             val item = sortedOther[i]
             val durationMinutes = if (i < sortedOther.lastIndex) {
-                java.time.Duration.between(item.pumpTime, sortedOther[i + 1].pumpTime)
+                java.time.Duration.between(item.pumpTimeLocal(), sortedOther[i + 1].pumpTimeLocal())
                     .toMinutes().toInt().coerceIn(1, 120)
             } else {
                 5 // default for last/only event
@@ -153,7 +153,7 @@ class ProcessBasal(
 
                 NightscoutTreatment.fromTimestamp(
                     eventType = "Temp Basal",
-                    timestamp = item.pumpTime,
+                    timestamp = item.pumpTimeLocal(),
                     seqId = item.seqId,
                     rate = commandedRate,
                     absolute = commandedRate,
@@ -170,7 +170,7 @@ class ProcessBasal(
 
                 NightscoutTreatment.fromTimestamp(
                     eventType = "Temp Basal",
-                    timestamp = item.pumpTime,
+                    timestamp = item.pumpTimeLocal(),
                     seqId = item.seqId,
                     rate = parsed.commandBasalRate.toDouble(),
                     absolute = parsed.commandBasalRate.toDouble(),

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/processors/ProcessBasalResume.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/processors/ProcessBasalResume.kt
@@ -69,7 +69,7 @@ class ProcessBasalResume(
                 val insulinAmount = parsed.insulinAmount / 1000.0
                 NightscoutTreatment.fromTimestamp(
                     eventType = "Note",
-                    timestamp = item.pumpTime,
+                    timestamp = item.pumpTimeLocal(),
                     seqId = item.seqId,
                     reason = "Pumping resumed",
                     notes = "Pumping resumed, IOB: ${insulinAmount}U"
@@ -78,7 +78,7 @@ class ProcessBasalResume(
             is HypoMinimizerResumeHistoryLog -> {
                 NightscoutTreatment.fromTimestamp(
                     eventType = "Note",
-                    timestamp = item.pumpTime,
+                    timestamp = item.pumpTimeLocal(),
                     seqId = item.seqId,
                     reason = "Hypo Minimizer resume",
                     notes = "Hypo Minimizer resume, reason code: ${parsed.reason}"

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/processors/ProcessBasalSuspension.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/processors/ProcessBasalSuspension.kt
@@ -69,7 +69,7 @@ class ProcessBasalSuspension(
                 val insulinAmount = parsed.insulinAmount / 1000.0
                 NightscoutTreatment.fromTimestamp(
                     eventType = "Temp Basal",
-                    timestamp = item.pumpTime,
+                    timestamp = item.pumpTimeLocal(),
                     seqId = item.seqId,
                     rate = 0.0,
                     absolute = 0.0,
@@ -81,7 +81,7 @@ class ProcessBasalSuspension(
             is HypoMinimizerSuspendHistoryLog -> {
                 NightscoutTreatment.fromTimestamp(
                     eventType = "Temp Basal",
-                    timestamp = item.pumpTime,
+                    timestamp = item.pumpTimeLocal(),
                     seqId = item.seqId,
                     rate = 0.0,
                     absolute = 0.0,

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/processors/ProcessBolus.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/processors/ProcessBolus.kt
@@ -89,7 +89,7 @@ class ProcessBolus(
 
         return NightscoutTreatment.fromTimestamp(
             eventType = "Bolus",
-            timestamp = item.pumpTime,
+            timestamp = item.pumpTimeLocal(),
             seqId = item.seqId,
             insulin = totalInsulin,
             notes = notes
@@ -126,7 +126,7 @@ class ProcessBolus(
 
         return NightscoutTreatment.fromTimestamp(
             eventType = "Combo Bolus",
-            timestamp = item.pumpTime,
+            timestamp = item.pumpTimeLocal(),
             seqId = item.seqId,
             insulin = immediateInsulin,
             duration = extendedDurationMinutes,

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/processors/ProcessCGMAlert.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/processors/ProcessCGMAlert.kt
@@ -83,7 +83,7 @@ class ProcessCGMAlert(
 
                 NightscoutTreatment.fromTimestamp(
                     eventType = "Announcement",
-                    timestamp = item.pumpTime,
+                    timestamp = item.pumpTimeLocal(),
                     seqId = item.seqId,
                     reason = reason,
                     notes = "CGM alert activated, ID: ${parsed.alertId}"
@@ -99,7 +99,7 @@ class ProcessCGMAlert(
 
                 NightscoutTreatment.fromTimestamp(
                     eventType = "Announcement",
-                    timestamp = item.pumpTime,
+                    timestamp = item.pumpTimeLocal(),
                     seqId = item.seqId,
                     reason = reason,
                     notes = "CGM alert cleared, ID: ${parsed.alertId}"
@@ -115,7 +115,7 @@ class ProcessCGMAlert(
 
                 NightscoutTreatment.fromTimestamp(
                     eventType = "Announcement",
-                    timestamp = item.pumpTime,
+                    timestamp = item.pumpTimeLocal(),
                     seqId = item.seqId,
                     reason = reason,
                     notes = "Dexcom alert activated, ID: ${parsed.alertId}"
@@ -131,7 +131,7 @@ class ProcessCGMAlert(
 
                 NightscoutTreatment.fromTimestamp(
                     eventType = "Announcement",
-                    timestamp = item.pumpTime,
+                    timestamp = item.pumpTimeLocal(),
                     seqId = item.seqId,
                     reason = reason,
                     notes = "Dexcom alert cleared, ID: ${parsed.alertId}"
@@ -147,7 +147,7 @@ class ProcessCGMAlert(
 
                 NightscoutTreatment.fromTimestamp(
                     eventType = "Announcement",
-                    timestamp = item.pumpTime,
+                    timestamp = item.pumpTimeLocal(),
                     seqId = item.seqId,
                     reason = reason,
                     notes = "FreeStyle Libre alert activated, ID: ${parsed.alertId}"
@@ -163,7 +163,7 @@ class ProcessCGMAlert(
 
                 NightscoutTreatment.fromTimestamp(
                     eventType = "Announcement",
-                    timestamp = item.pumpTime,
+                    timestamp = item.pumpTimeLocal(),
                     seqId = item.seqId,
                     reason = reason,
                     notes = "FreeStyle Libre alert cleared, ID: ${parsed.alertId}"

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/processors/ProcessCGMReading.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/processors/ProcessCGMReading.kt
@@ -11,7 +11,6 @@ import com.jwoglom.pumpx2.pump.messages.response.historyLog.DexcomG6CGMHistoryLo
 import com.jwoglom.pumpx2.pump.messages.response.historyLog.DexcomG7CGMHistoryLog
 import com.jwoglom.pumpx2.pump.messages.response.historyLog.HistoryLogParser
 import timber.log.Timber
-import java.time.LocalDateTime
 
 /**
  * Process CGM readings (glucose values) for Nightscout upload
@@ -47,7 +46,7 @@ class ProcessCGMReading(
             try {
                 val (sgv, _) = extractGlucose(item) ?: return@mapNotNull null
                 if (sgv <= 0) return@mapNotNull null
-                Triple(item, item.pumpTime, sgv)
+                Triple(item, item.pumpTimeLocal(), sgv)
             } catch (e: Exception) {
                 Timber.e(e, "Failed to parse CGM reading seqId=${item.seqId}")
                 null

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/processors/ProcessCarb.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/processors/ProcessCarb.kt
@@ -74,7 +74,7 @@ class ProcessCarb(
 
         return NightscoutTreatment.fromTimestamp(
             eventType = "Carb Correction",
-            timestamp = item.pumpTime,
+            timestamp = item.pumpTimeLocal(),
             seqId = item.seqId,
             carbs = carbs.toDouble(),
             notes = "Carb entry: ${carbs}g"

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/processors/ProcessCartridge.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/processors/ProcessCartridge.kt
@@ -70,7 +70,7 @@ class ProcessCartridge(
             is CartridgeFilledHistoryLog -> {
                 NightscoutTreatment.fromTimestamp(
                     eventType = "Insulin Change",
-                    timestamp = item.pumpTime,
+                    timestamp = item.pumpTimeLocal(),
                     seqId = item.seqId,
                     notes = "Cartridge filled with ${parsed.insulinDisplay}U (actual: ${parsed.insulinActual}U)"
                 )
@@ -78,7 +78,7 @@ class ProcessCartridge(
             is TubingFilledHistoryLog -> {
                 NightscoutTreatment.fromTimestamp(
                     eventType = "Site Change",
-                    timestamp = item.pumpTime,
+                    timestamp = item.pumpTimeLocal(),
                     seqId = item.seqId,
                     notes = "Tubing filled/primed with ${parsed.primeSize}U"
                 )
@@ -86,7 +86,7 @@ class ProcessCartridge(
             is CannulaFilledHistoryLog -> {
                 NightscoutTreatment.fromTimestamp(
                     eventType = "Site Change",
-                    timestamp = item.pumpTime,
+                    timestamp = item.pumpTimeLocal(),
                     seqId = item.seqId,
                     notes = "Cannula filled/primed with ${parsed.primeSize}U"
                 )

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/processors/ProcessDeviceStatus.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/processors/ProcessDeviceStatus.kt
@@ -43,7 +43,7 @@ class ProcessDeviceStatus(
         }
 
         // Sort chronologically and accumulate composite state from all logs
-        val sortedLogs = logs.sortedBy { it.pumpTime }
+        val sortedLogs = logs.sortedBy { it.pumpTimeLocal() }
 
         var latestBattery: Int? = null
         var latestIob: Double? = null
@@ -75,7 +75,7 @@ class ProcessDeviceStatus(
             return 0
         }
 
-        val latestTimestamp = sortedLogs.last().pumpTime
+        val latestTimestamp = sortedLogs.last().pumpTimeLocal()
         val deviceStatus = createDeviceStatus(
             timestamp = latestTimestamp,
             batteryPercent = latestBattery,

--- a/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/processors/ProcessUserMode.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/sync/nightscout/processors/ProcessUserMode.kt
@@ -82,7 +82,7 @@ class ProcessUserMode(
 
                 NightscoutTreatment.fromTimestamp(
                     eventType = eventType,
-                    timestamp = item.pumpTime,
+                    timestamp = item.pumpTimeLocal(),
                     seqId = item.seqId,
                     duration = null,
                     reason = "Control-IQ mode changed to $modeName",

--- a/mobile/src/main/java/com/jwoglom/controlx2/util/HistoryLogFetcher.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/util/HistoryLogFetcher.kt
@@ -226,6 +226,7 @@ class HistoryLogFetcher(
                 pumpSid = pumpSid,
                 typeId = log.typeId(),
                 cargo = log.cargo,
+                pumpTimeSec = log.pumpTimeSec,
                 pumpTime = LocalDateTime.ofInstant(log.pumpTimeSecInstant, ZoneId.systemDefault()),
                 addedTime = LocalDateTime.now()
             )


### PR DESCRIPTION
## Summary
This PR refactors the pump time handling throughout the codebase to use a more reliable epoch-seconds-based approach instead of directly storing `LocalDateTime` objects. A new `pumpTimeLocal()` method is introduced to derive wall-clock time from the underlying `pumpTimeSec` field.

## Key Changes

- **Added `pumpTimeLocal()` method** to `HistoryLogItem`: Derives local `LocalDateTime` from `pumpTimeSec` using the pump's epoch (January 1, 2008) as the reference point, replacing direct access to the deprecated `pumpTime` field

- **Updated database schema**: Changed `HistoryLogTypeStats.latestPumpTime` from `LocalDateTime?` to `latestPumpTimeSec: Long?` to store raw epoch seconds instead of serialized datetime objects

- **Migrated all timestamp usages**: Updated 15+ processor classes and utility files to call `pumpTimeLocal()` instead of accessing `pumpTime` directly:
  - Nightscout processors: `ProcessBasal`, `ProcessBolus`, `ProcessCarb`, `ProcessCGMAlert`, `ProcessCGMReading`, `ProcessAlarm`, `ProcessCartridge`, `ProcessBasalResume`, `ProcessBasalSuspension`, `ProcessUserMode`, `ProcessDeviceStatus`
  - Sync coordinators and utilities: `NightscoutSyncCoordinator`, `HistoryLogFetcher`, `VicoCgmChart`

- **Enhanced API responses**: 
  - Added `pumpTimeSec` field to JSON responses for direct access to epoch seconds
  - Updated type stats endpoint to include both raw `latestPumpTimeSec` and computed `latestPumpTime` for backward compatibility

- **Improved time range filtering**: Updated `filterByTimeRange()` method to use `pumpTimeLocal()` for consistent datetime comparisons

## Implementation Details

The refactoring uses `java.time.LocalDateTime.ofEpochSecond()` with `ZoneOffset.UTC` to convert from pump epoch seconds to UTC datetime, then allows callers to apply their own timezone conversions as needed. This approach is more robust than storing serialized `LocalDateTime` objects and ensures consistent time handling across the application.

https://claude.ai/code/session_01FqRgf6Gyoam6ZDzQavPLwo