### PR TITLE
Document SendType enum and adjust cache strategy defaults

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/CartridgeActions.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/CartridgeActions.kt
@@ -112,7 +112,7 @@ fun CartridgeActions(
         sendPumpCommands(type, cartridgeActionsCommands)
     }
 
-    fun refreshNotifications(type: SendType = SendType.BUST_CACHE) = refreshScope.launch {
+    fun refreshNotifications(type: SendType = SendType.STANDARD) = refreshScope.launch {
         if (!Prefs(context).serviceEnabled()) return@launch
         notificationsRefreshing = true
         sendPumpCommands(type, cartridgeNotificationCommands)
@@ -127,7 +127,7 @@ fun CartridgeActions(
         }
     }
 
-    fun refreshWorkflowState(type: SendType = SendType.BUST_CACHE) {
+    fun refreshWorkflowState(type: SendType = SendType.STANDARD) {
         sendPumpCommands(
             type,
             listOf(

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/ProfileActions.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/ProfileActions.kt
@@ -139,7 +139,7 @@ fun ProfileActions(
             if (messagesSent.containsAll(nextMessages.map { it.cargo })) {
                 Timber.i("profileActions round${round} loading: remaining ${nextMessages?.size} sent ${messagesSent.size}")
                 if (sinceLastFetchTime >= 2500) {
-                    Timber.i("profileActions round${round} loading re-fetching with bust_cache")
+                    Timber.i("profileActions round${round} loading re-fetching with standard")
                     sendPumpCommands(SendType.STANDARD, nextMessages)
                     sinceLastFetchTime = 0
                     attempts++

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/NotificationItem.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/NotificationItem.kt
@@ -63,7 +63,7 @@ fun NotificationItem(
             when (notification) {
                 is AlertStatusResponse.AlertResponseType -> {
                     sendPumpCommands(
-                        SendType.BUST_CACHE, listOf(
+                        SendType.STANDARD, listOf(
                             DismissNotificationRequest(
                                 DismissNotificationRequest.NotificationType.ALERT,
                                 notification.bitmask().toLong()
@@ -74,7 +74,7 @@ fun NotificationItem(
 
                 is ReminderStatusResponse.ReminderType -> {
                     sendPumpCommands(
-                        SendType.BUST_CACHE, listOf(
+                        SendType.STANDARD, listOf(
                             DismissNotificationRequest(
                                 DismissNotificationRequest.NotificationType.REMINDER,
                                 notification.id().toLong()
@@ -85,7 +85,7 @@ fun NotificationItem(
 
                 is AlarmStatusResponse.AlarmResponseType -> {
                     sendPumpCommands(
-                        SendType.BUST_CACHE, listOf(
+                        SendType.STANDARD, listOf(
                             DismissNotificationRequest(
                                 DismissNotificationRequest.NotificationType.ALARM,
                                 notification.bitmask().toLong()
@@ -96,7 +96,7 @@ fun NotificationItem(
 
                 is CGMAlertStatusResponse.CGMAlert -> {
                     sendPumpCommands(
-                        SendType.BUST_CACHE, listOf(
+                        SendType.STANDARD, listOf(
                             DismissNotificationRequest(
                                 DismissNotificationRequest.NotificationType.CGM_ALERT,
                                 notification.id().toLong()

--- a/shared/src/main/java/com/jwoglom/controlx2/shared/util/SendType.kt
+++ b/shared/src/main/java/com/jwoglom/controlx2/shared/util/SendType.kt
@@ -1,8 +1,44 @@
 package com.jwoglom.controlx2.shared.util
 
+/**
+ * Controls how an outgoing pump command interacts with the 30-second response
+ * cache maintained in PumpCommHandler.
+ *
+ * Use the smallest hammer that does the job:
+ * - Prefer [STANDARD] for periodic refreshes and lifecycle/onStart fetches.
+ * - Use [BUST_CACHE] only when the user explicitly asked for fresh data
+ *   (pull-to-refresh) or immediately after a write that invalidates known state.
+ * - Use [CACHED] inside retry loops (e.g. waitForLoaded) where a fresh read just
+ *   happened and we are willing to accept the cached response if available.
+ * - [DEBUG_PROMPT] is reserved for the developer Debug screen.
+ */
 enum class SendType(val slug: String) {
+    /**
+     * Sends the command to the pump normally. Does not read or clear the cache
+     * on the request side; the response will populate the cache for subsequent
+     * CACHED reads. Default choice for periodic / lifecycle refreshes.
+     */
     STANDARD("commands"),
+
+    /**
+     * Removes any cached entry for this opcode and then sends to the pump.
+     * Guarantees the next response is fresh from the pump. Use for explicit
+     * user-initiated refreshes and immediately after mutating commands where
+     * we know the cached value is now stale.
+     */
     BUST_CACHE("commands-bust-cache"),
+
+    /**
+     * Returns the cached response immediately if it is <= 30 seconds old.
+     * Otherwise falls through to a normal pump send. Intended for retry loops
+     * (waitForLoaded) where a real fetch was issued moments ago and we want to
+     * pick up the response without re-sending if it has already arrived.
+     */
     CACHED("cached-commands"),
+
+    /**
+     * Routes the command through the developer debug path. Responses are
+     * tracked separately for the Debug screen. Do not use from production UI.
+     */
     DEBUG_PROMPT("debug-commands"),
 }

--- a/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/LandingScreen.kt
+++ b/wear/src/main/java/com/jwoglom/controlx2/presentation/ui/LandingScreen.kt
@@ -138,11 +138,11 @@ fun LandingScreen(
     LifecycleStateObserver(lifecycleOwner = LocalLifecycleOwner.current, onStop = {
         refreshScope.cancel()
     }) {
-        fetchDataStoreFields(SendType.BUST_CACHE)
+        fetchDataStoreFields(SendType.STANDARD)
     }
 
     LaunchedEffect(intervalOf(60)) {
-        fetchDataStoreFields(SendType.BUST_CACHE)
+        fetchDataStoreFields(SendType.STANDARD)
     }
 
     LaunchedEffect(refreshing) {


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation to the `SendType` enum explaining the cache interaction behavior of each variant, and adjusts several call sites to use more appropriate cache strategies based on the documented guidelines.

## Key Changes

- **SendType.kt**: Added detailed KDoc comments explaining:
  - The purpose of each `SendType` variant (STANDARD, BUST_CACHE, CACHED, DEBUG_PROMPT)
  - When to use each variant with clear guidance on choosing the "smallest hammer"
  - How each variant interacts with the 30-second response cache in PumpCommHandler

- **NotificationItem.kt**: Changed 4 notification dismissal operations from `BUST_CACHE` to `STANDARD`
  - Alert, Reminder, Alarm, and CGM Alert dismissals now use STANDARD
  - These are write operations where the response itself provides fresh state, so cache busting is unnecessary

- **CartridgeActions.kt**: Changed default `SendType` parameter from `BUST_CACHE` to `STANDARD` for:
  - `refreshNotifications()` function
  - `refreshWorkflowState()` function
  - These are periodic/lifecycle refreshes that don't require aggressive cache invalidation

- **LandingScreen.kt (Wear)**: Changed 2 periodic fetch operations from `BUST_CACHE` to `STANDARD`
  - onStart lifecycle fetch
  - 60-second interval fetch
  - These are routine data refreshes, not user-initiated explicit refreshes

- **ProfileActions.kt**: Updated log message to reflect strategy change from "bust_cache" to "standard"

## Implementation Details
The changes follow the documented guidance that `STANDARD` should be the default for periodic refreshes and lifecycle operations, reserving `BUST_CACHE` for explicit user-initiated refreshes (pull-to-refresh) and immediately after mutations where cached state is known to be stale.

https://claude.ai/code/session_01HVszADqCuwoMAWv2soamPH