### PR TITLE
Add cloud-setup.sh bootstrap script for Claude Code sandbox

### DIFF
--- a/.claude/cloud-setup.sh
+++ b/.claude/cloud-setup.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# Bootstrap script for Claude Code cloud sessions on controlX2.
+#
+# Installs Android SDK components, Robolectric offline JARs, and writes the
+# session-wide env vars Gradle/AGP need. Idempotent — safe to re-run.
+set -euo pipefail
+
+REPO_ROOT="/home/user/controlX2"
+SDK_ROOT="$REPO_ROOT/.android-sdk"
+
+# ── Helper functions ──
+
+# download_with_retry <url> <dest>
+download_with_retry() {
+  local url="$1"
+  local dest="$2"
+  if curl -sL --fail "$url" -o "$dest"; then
+    return 0
+  fi
+  echo "Download failed for $url — retrying in 10s..."
+  sleep 10
+  curl -sL --fail "$url" -o "$dest" || {
+    echo "ERROR: Download failed twice for $url" >&2
+    return 1
+  }
+}
+
+# download_and_unzip <url> <tmp_zip> <dest_dir>
+download_and_unzip() {
+  local url="$1"
+  local tmp_zip="$2"
+  local dest_dir="$3"
+  download_with_retry "$url" "$tmp_zip"
+  if ! unzip -qo "$tmp_zip" -d "$dest_dir"; then
+    echo "Extraction failed for $tmp_zip — re-downloading in 10s..."
+    sleep 10
+    rm -f "$tmp_zip"
+    download_with_retry "$url" "$tmp_zip"
+    unzip -qo "$tmp_zip" -d "$dest_dir" || {
+      echo "ERROR: Extraction failed after re-download of $url" >&2
+      return 1
+    }
+  fi
+  rm -f "$tmp_zip"
+}
+
+# ── Install Android SDK components directly ──
+mkdir -p "$SDK_ROOT"
+
+if [[ ! -f "$SDK_ROOT/build-tools/35.0.0/aapt2" ]]; then
+  echo "Downloading build-tools 35.0.0..."
+  mkdir -p "$SDK_ROOT/build-tools/35.0.0"
+  download_and_unzip \
+    "https://dl.google.com/android/repository/build-tools_r35_linux.zip" \
+    /tmp/bt35.zip \
+    "$SDK_ROOT/build-tools/35.0.0/"
+  mv "$SDK_ROOT/build-tools/35.0.0/android-"*/* "$SDK_ROOT/build-tools/35.0.0/" 2>/dev/null || true
+
+  cat > "$SDK_ROOT/build-tools/35.0.0/package.xml" << 'XML'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns2:repository xmlns:ns2="http://schemas.android.com/repository/android/common/02" xmlns:ns7="http://schemas.android.com/sdk/android/repo/repository2/03">
+    <localPackage path="build-tools;35.0.0" obsolete="false">
+        <type-details xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ns7:genericDetailsType"/>
+        <revision><major>35</major><minor>0</minor><micro>0</micro></revision>
+        <display-name>Android SDK Build-Tools 35</display-name>
+    </localPackage>
+</ns2:repository>
+XML
+fi
+
+if [[ ! -d "$SDK_ROOT/platforms/android-35" ]]; then
+  echo "Downloading platform android-35..."
+  download_and_unzip \
+    "https://dl.google.com/android/repository/platform-35_r02.zip" \
+    /tmp/p35.zip \
+    "$SDK_ROOT/platforms/"
+
+  cat > "$SDK_ROOT/platforms/android-35/package.xml" << 'XML'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns2:repository xmlns:ns2="http://schemas.android.com/repository/android/common/02" xmlns:ns7="http://schemas.android.com/sdk/android/repo/repository2/03">
+    <localPackage path="platforms;android-35" obsolete="false">
+        <type-details xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ns7:platformDetailsType"><api-level>35</api-level></type-details>
+        <revision><major>2</major></revision>
+        <display-name>Android SDK Platform 35</display-name>
+    </localPackage>
+</ns2:repository>
+XML
+fi
+
+if [[ ! -d "$SDK_ROOT/platforms/android-36" ]]; then
+  echo "Downloading platform android-36..."
+  download_and_unzip \
+    "https://dl.google.com/android/repository/platform-36_r02.zip" \
+    /tmp/p36.zip \
+    "$SDK_ROOT/platforms/"
+
+  cat > "$SDK_ROOT/platforms/android-36/package.xml" << 'XML'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns2:repository xmlns:ns2="http://schemas.android.com/repository/android/common/02" xmlns:ns7="http://schemas.android.com/sdk/android/repo/repository2/03">
+    <localPackage path="platforms;android-36" obsolete="false">
+        <type-details xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ns7:platformDetailsType"><api-level>36</api-level></type-details>
+        <revision><major>2</major></revision>
+        <display-name>Android SDK Platform 36</display-name>
+    </localPackage>
+</ns2:repository>
+XML
+fi
+
+# ── Create local.properties ──
+cat > "$REPO_ROOT/local.properties" << EOF
+sdk.dir=$SDK_ROOT
+use_local_pumpx2=false
+EOF
+echo "local.properties written"
+
+# ── Download Robolectric offline JARs ──
+# Robolectric downloads instrumented Android JARs at test time.
+# mobile/build.gradle enables offline mode when CI=true (set below);
+# we just need the JARs pre-placed in ~/.robolectric/.
+mkdir -p ~/.robolectric
+
+ROBOLECTRIC_REPO="https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented"
+
+if [[ ! -f ~/.robolectric/android-all-instrumented-14-robolectric-10818077-i7.jar ]]; then
+  echo "Downloading Robolectric SDK 14 (Android 34) jar..."
+  download_with_retry \
+    "$ROBOLECTRIC_REPO/14-robolectric-10818077-i7/android-all-instrumented-14-robolectric-10818077-i7.jar" \
+    ~/.robolectric/android-all-instrumented-14-robolectric-10818077-i7.jar
+fi
+
+if [[ ! -f ~/.robolectric/android-all-instrumented-15-robolectric-13954326-i7.jar ]]; then
+  echo "Downloading Robolectric SDK 15 (Android 35) jar..."
+  download_with_retry \
+    "$ROBOLECTRIC_REPO/15-robolectric-13954326-i7/android-all-instrumented-15-robolectric-13954326-i7.jar" \
+    ~/.robolectric/android-all-instrumented-15-robolectric-13954326-i7.jar
+fi
+
+# ── Export session-wide environment variables ──
+# ANDROID_HOME / ANDROID_SDK_ROOT: required for Gradle/AGP commands. Both names
+#   are written because different tools (and agent sanity checks) read different
+#   ones.
+# CI=true: activates Robolectric offline mode in mobile/build.gradle (see the
+#   `if (System.getenv('CI') == 'true')` block in testOptions). Without this,
+#   Robolectric tries to fetch the instrumented JAR at test time and gets a 503
+#   from Maven Central in this environment.
+#
+# Belt-and-suspenders: write to $CLAUDE_ENV_FILE (Claude Code's preferred
+# mechanism) AND ~/.bashrc, because in past sessions a session-level
+# ANDROID_HOME=$REPO_ROOT/.android-sdk literal-string env was clobbering the
+# CLAUDE_ENV_FILE write and leaving agents thinking the SDK was missing.
+write_env_var() {
+  local target="$1"
+  local key="$2"
+  local value="$3"
+  [[ -z "$target" ]] && return 0
+  # Remove any prior export of this key, then append the fresh one.
+  if [[ -f "$target" ]]; then
+    sed -i "\|^export $key=|d" "$target" 2>/dev/null || true
+  fi
+  echo "export $key=$value" >> "$target"
+}
+
+for target in "${CLAUDE_ENV_FILE:-}" "$HOME/.bashrc"; do
+  write_env_var "$target" ANDROID_HOME "$SDK_ROOT"
+  write_env_var "$target" ANDROID_SDK_ROOT "$SDK_ROOT"
+  write_env_var "$target" CI true
+done
+
+export ANDROID_HOME="$SDK_ROOT"
+export ANDROID_SDK_ROOT="$SDK_ROOT"
+export CI=true
+
+# ── Sanity check ──
+# A platform-level session env var sometimes ships with the literal string
+# "$REPO_ROOT/.android-sdk" (REPO_ROOT unset) and overrides CLAUDE_ENV_FILE.
+# This catches that drift in future sessions before agents go down a rabbit hole.
+expected="$SDK_ROOT"
+warn=0
+for var in ANDROID_HOME ANDROID_SDK_ROOT; do
+  actual="$(printenv "$var" || true)"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "WARNING: $var=$actual (expected $expected) — check session-level env config" >&2
+    warn=1
+  fi
+done
+
+echo "Checking gradle dependencies..."
+(cd "$REPO_ROOT" && ./gradlew dependencies --quiet)
+
+echo "Setup complete!"
+echo "  SDK: $SDK_ROOT"
+echo "  Robolectric JARs: ~/.robolectric/"
+echo ""
+echo "Build:  ./gradlew :mobile:compileDebugKotlin"
+echo "Test:   ./gradlew testDebugUnitTest"
+[[ "$warn" -eq 1 ]] && echo "(See WARNING above — env may still be misconfigured at session level.)"
+exit 0

--- a/.claude/cloud-setup.sh
+++ b/.claude/cloud-setup.sh
@@ -107,11 +107,15 @@ XML
 fi
 
 # ── Create local.properties ──
-cat > "$REPO_ROOT/local.properties" << EOF
+LOCAL_PROPS_EXPECTED="sdk.dir=$SDK_ROOT
+use_local_pumpx2=false"
+if [[ ! -f "$REPO_ROOT/local.properties" ]] || [[ "$(cat "$REPO_ROOT/local.properties")" != "$LOCAL_PROPS_EXPECTED" ]]; then
+  cat > "$REPO_ROOT/local.properties" << EOF
 sdk.dir=$SDK_ROOT
 use_local_pumpx2=false
 EOF
-echo "local.properties written"
+  echo "local.properties written"
+fi
 
 # ── Download Robolectric offline JARs ──
 # Robolectric downloads instrumented Android JARs at test time.
@@ -152,12 +156,18 @@ write_env_var() {
   local target="$1"
   local key="$2"
   local value="$3"
+  local expected="export $key=$value"
   [[ -z "$target" ]] && return 0
-  # Remove any prior export of this key, then append the fresh one.
+  # Skip if the file already has the exact line we'd write.
+  if [[ -f "$target" ]] && grep -Fxq "$expected" "$target"; then
+    return 0
+  fi
+  # Drop any stale export of this key, then append the fresh one.
   if [[ -f "$target" ]]; then
     sed -i "\|^export $key=|d" "$target" 2>/dev/null || true
   fi
-  echo "export $key=$value" >> "$target"
+  echo "$expected" >> "$target"
+  echo "wrote $key=$value to $target"
 }
 
 for target in "${CLAUDE_ENV_FILE:-}" "$HOME/.bashrc"; do
@@ -184,8 +194,20 @@ for var in ANDROID_HOME ANDROID_SDK_ROOT; do
   fi
 done
 
-echo "Checking gradle dependencies..."
-(cd "$REPO_ROOT" && ./gradlew dependencies --quiet)
+# ── Warm Gradle dependency cache ──
+# Slow (multiple minutes), so gate on a sentinel that records the SDK + script
+# version we cached against. Bump CACHE_VERSION when you change SDK components
+# or anything else that should invalidate the cached resolution.
+CACHE_VERSION="1"
+DEPS_SENTINEL="$SDK_ROOT/.gradle-deps-warmed"
+DEPS_TOKEN="$CACHE_VERSION:$SDK_ROOT"
+if [[ ! -f "$DEPS_SENTINEL" ]] || [[ "$(cat "$DEPS_SENTINEL")" != "$DEPS_TOKEN" ]]; then
+  echo "Warming gradle dependencies..."
+  (cd "$REPO_ROOT" && ./gradlew dependencies --quiet)
+  echo "$DEPS_TOKEN" > "$DEPS_SENTINEL"
+else
+  echo "Gradle dependencies already warmed (skipping)"
+fi
 
 echo "Setup complete!"
 echo "  SDK: $SDK_ROOT"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,130 +190,26 @@ Then use the standard commands documented in the "Running & testing" section abo
 - The root `build.gradle` reads `local.properties` eagerly at configuration time. If `local.properties` is missing, Gradle will fail immediately. Always run `.codex/setup.sh` first.
 - Roborazzi screenshot tests: record with `./gradlew :mobile:recordRoborazziDebug :wear:recordRoborazziDebug`, verify with `./gradlew :mobile:verifyRoborazziDebug :wear:verifyRoborazziDebug`. Golden images are stored in each module's test snapshots directory.
 
-## Claude Code cloud-specific instructions
+## Claude Code cloud sandbox specific instructions
 
-### Environment prerequisites
-- The VM has JDK 21 pre-installed and a repo-local Android SDK at `.android-sdk/` with only `cmdline-tools` pre-installed.
-- The environment routes all outbound traffic through an authenticated HTTP proxy configured via `JAVA_TOOL_OPTIONS`. The proxy credentials (user/password) are embedded in that env var.
+The Claude Code cloud sandbox bootstraps the Android SDK and Robolectric offline JARs automatically before the agent starts, by running `.claude/cloud-setup.sh`. After that script completes:
 
-### Bootstrapping Gradle and the Android SDK
-
-**1. Configure Gradle proxy settings** — Gradle needs explicit proxy config in `~/.gradle/gradle.properties`. Extract the proxy credentials from `JAVA_TOOL_OPTIONS` and write them:
-
-```bash
-PROXY_USER=$(echo "$JAVA_TOOL_OPTIONS" | grep -oP '(?<=-Dhttp.proxyUser=)[^ ]+')
-PROXY_PASS=$(echo "$JAVA_TOOL_OPTIONS" | grep -oP '(?<=-Dhttp.proxyPassword=)[^ ]+')
-
-cat > ~/.gradle/gradle.properties << EOF
-systemProp.http.proxyHost=21.0.0.17
-systemProp.http.proxyPort=15004
-systemProp.https.proxyHost=21.0.0.17
-systemProp.https.proxyPort=15004
-systemProp.http.proxyUser=$PROXY_USER
-systemProp.http.proxyPassword=$PROXY_PASS
-systemProp.https.proxyUser=$PROXY_USER
-systemProp.https.proxyPassword=$PROXY_PASS
-systemProp.http.nonProxyHosts=localhost|127.0.0.1
-systemProp.jdk.http.auth.tunneling.disabledSchemes=
-systemProp.jdk.http.auth.proxying.disabledSchemes=
-org.gradle.jvmargs=-Xmx4g -Dhttp.nonProxyHosts=localhost|127.0.0.1
-EOF
-```
-
-> **Important:** The default `JAVA_TOOL_OPTIONS` includes `*.googleapis.com|*.google.com` in `http.nonProxyHosts`, which bypasses the proxy for Google domains. This breaks the Android SDK manager (which downloads from `dl.google.com`). The Gradle properties above override this with a minimal nonProxyHosts list.
-
-**2. Install Android SDK components manually** — The `sdkmanager` CLI also fails to download through the proxy because it inherits the broken `nonProxyHosts` from `JAVA_TOOL_OPTIONS`. Download build-tools and platform JARs directly using `curl`:
-
-```bash
-PROXY="http://${PROXY_USER}:${PROXY_PASS}@21.0.0.17:15004"
-SDK=.android-sdk
-
-# Download build-tools 35.0.0
-curl -x "$PROXY" -sL "https://dl.google.com/android/repository/build-tools_r35_linux.zip" -o /tmp/bt35.zip
-mkdir -p "$SDK/build-tools/35.0.0"
-unzip -qo /tmp/bt35.zip -d "$SDK/build-tools/35.0.0/"
-# The zip extracts into a subdirectory (e.g. android-15/) — move contents up
-mv "$SDK/build-tools/35.0.0/android-"*/* "$SDK/build-tools/35.0.0/"
-
-# Download platforms
-curl -x "$PROXY" -sL "https://dl.google.com/android/repository/platform-35_r02.zip" -o /tmp/p35.zip
-curl -x "$PROXY" -sL "https://dl.google.com/android/repository/platform-36_r02.zip" -o /tmp/p36.zip
-unzip -qo /tmp/p35.zip -d "$SDK/platforms/"
-unzip -qo /tmp/p36.zip -d "$SDK/platforms/"
-```
-
-**3. Create `package.xml` files** — AGP requires these metadata files to recognize SDK components:
-
-```bash
-# build-tools/35.0.0/package.xml
-cat > "$SDK/build-tools/35.0.0/package.xml" << 'XML'
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:repository xmlns:ns2="http://schemas.android.com/repository/android/common/02" xmlns:ns7="http://schemas.android.com/sdk/android/repo/repository2/03">
-    <localPackage path="build-tools;35.0.0" obsolete="false">
-        <type-details xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ns7:genericDetailsType"/>
-        <revision><major>35</major><minor>0</minor><micro>0</micro></revision>
-        <display-name>Android SDK Build-Tools 35</display-name>
-    </localPackage>
-</ns2:repository>
-XML
-
-# platforms/android-35/package.xml
-cat > "$SDK/platforms/android-35/package.xml" << 'XML'
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:repository xmlns:ns2="http://schemas.android.com/repository/android/common/02" xmlns:ns7="http://schemas.android.com/sdk/android/repo/repository2/03">
-    <localPackage path="platforms;android-35" obsolete="false">
-        <type-details xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ns7:platformDetailsType"><api-level>35</api-level><codename></codename></type-details>
-        <revision><major>2</major></revision>
-        <display-name>Android SDK Platform 35</display-name>
-    </localPackage>
-</ns2:repository>
-XML
-
-# platforms/android-36/package.xml
-cat > "$SDK/platforms/android-36/package.xml" << 'XML'
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:repository xmlns:ns2="http://schemas.android.com/repository/android/common/02" xmlns:ns7="http://schemas.android.com/sdk/android/repo/repository2/03">
-    <localPackage path="platforms;android-36" obsolete="false">
-        <type-details xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ns7:platformDetailsType"><api-level>36</api-level><codename></codename></type-details>
-        <revision><major>2</major></revision>
-        <display-name>Android SDK Platform 36</display-name>
-    </localPackage>
-</ns2:repository>
-XML
-```
-
-**4. Configure Robolectric for offline mode** — Robolectric downloads instrumented Android JARs at test time, which also fails through the proxy. Download them manually and configure offline mode:
-
-```bash
-# Download the instrumented JARs Robolectric needs
-mkdir -p ~/.robolectric
-curl -x "$PROXY" -sL "https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/14-robolectric-10818077-i7/android-all-instrumented-14-robolectric-10818077-i7.jar" \
-  -o ~/.robolectric/android-all-instrumented-14-robolectric-10818077-i7.jar
-curl -x "$PROXY" -sL "https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/15-robolectric-12650502-i7/android-all-instrumented-15-robolectric-12650502-i7.jar" \
-  -o ~/.robolectric/android-all-instrumented-15-robolectric-12650502-i7.jar
-```
-
-Then add Robolectric offline system properties to `mobile/build.gradle` inside `testOptions > unitTests > all`:
-```groovy
-systemProperty 'robolectric.offline', 'true'
-systemProperty 'robolectric.dependency.dir', "${System.getProperty('user.home')}/.robolectric"
-```
+- The Android SDK lives at `/home/user/controlX2/.android-sdk` with `build-tools;35.0.0`, `platforms;android-35`, and `platforms;android-36` pre-installed and `package.xml` files in place.
+- `local.properties` is written with `sdk.dir=/home/user/controlX2/.android-sdk` and `use_local_pumpx2=false`.
+- Robolectric instrumented JARs are pre-placed in `~/.robolectric/` and `CI=true` is exported so `mobile/build.gradle` activates Robolectric offline mode (no test-time downloads needed).
+- `ANDROID_HOME` and `ANDROID_SDK_ROOT` are exported to `/home/user/controlX2/.android-sdk` via `$CLAUDE_ENV_FILE` and `~/.bashrc`.
 
 ### Running builds and tests
+No manual env exports are needed. From the repo root:
 ```bash
-export ANDROID_HOME=/home/user/controlX2/.android-sdk
-
-# Compile
 ./gradlew :mobile:compileDebugKotlin
-
-# Run CommService integration tests
 ./gradlew :mobile:testDebugUnitTest --tests "com.jwoglom.controlx2.CommServiceIntegrationTest"
-
-# Full test suite
 ./gradlew :mobile:testDebugUnitTest
 ```
 
-### Key gotchas
-- The `JAVA_TOOL_OPTIONS` env var is read-only and set at container level. You cannot override its `nonProxyHosts` — instead, set the correct values in `~/.gradle/gradle.properties` which Gradle picks up as system properties for its own JVM.
-- SDK component URLs can be found by downloading the repository manifest: `curl -x "$PROXY" -sL "https://dl.google.com/android/repository/repository2-3.xml"` and searching for the package path.
-- If Robolectric tests fail with `MavenArtifactFetcher` / `407 Proxy Authentication Required`, the offline mode JARs are missing or the system property wasn't applied. Check that the JAR filenames match exactly what Robolectric requests (visible in `--info` output).
+### If the SDK appears missing
+If a Gradle command reports "SDK location not found" or `$ANDROID_HOME` looks wrong (e.g. resolves to a literal `$REPO_ROOT/.android-sdk`), the session env drifted from what `.claude/cloud-setup.sh` writes. Re-run the bootstrap from the repo root:
+```bash
+bash .claude/cloud-setup.sh
+```
+The script is idempotent — it re-asserts env vars in `$CLAUDE_ENV_FILE` and `~/.bashrc`, prints a `WARNING` if the running env still doesn't match the installed SDK path, and reinstalls any missing SDK components. If you see the warning, the platform-level session env is overriding the script's write and needs to be fixed at the cloud-config level rather than in the repo.


### PR DESCRIPTION
## Summary
Automates Android SDK and Robolectric setup for Claude Code cloud sandbox sessions by introducing a new bootstrap script (`.claude/cloud-setup.sh`) and updating documentation to reflect the automated setup flow.

## Key Changes

- **New bootstrap script** (`.claude/cloud-setup.sh`): Idempotent shell script that:
  - Downloads and installs Android SDK build-tools 35.0.0 and platforms android-35/36 with retry logic
  - Generates required `package.xml` metadata files for AGP recognition
  - Creates `local.properties` with correct SDK path
  - Pre-downloads Robolectric instrumented JARs (SDK 14 and 15) to `~/.robolectric/`
  - Exports `ANDROID_HOME`, `ANDROID_SDK_ROOT`, and `CI=true` to both `$CLAUDE_ENV_FILE` and `~/.bashrc` for persistence
  - Validates environment variables against session-level drift
  - Warms Gradle dependency cache with version-gated sentinel to avoid redundant runs

- **Updated AGENTS.md documentation**:
  - Replaced 130+ lines of manual setup instructions with concise post-bootstrap summary
  - Removed detailed proxy configuration, manual curl/unzip steps, and package.xml creation instructions
  - Added troubleshooting section for SDK detection issues with recovery instructions
  - Simplified "Running builds and tests" to just the command examples (no env exports needed)

## Implementation Details

- **Retry logic**: Download failures trigger a 10-second delay and one automatic retry before failing
- **Idempotency**: All operations check for existing files/directories and skip if already present; env var writes deduplicate exact lines to avoid accumulation
- **Belt-and-suspenders env export**: Writes to both `$CLAUDE_ENV_FILE` (Claude's mechanism) and `~/.bashrc` to handle cases where platform-level session env overrides one or the other
- **Sanity checks**: Post-export validation warns if running env doesn't match installed SDK path, helping diagnose session-level env drift
- **Dependency cache warming**: Gated by a sentinel file tracking `CACHE_VERSION` and `SDK_ROOT` to invalidate cache when SDK components change

https://claude.ai/code/session_01PBpz6hivdEDaPWDqkx8vDf