### PR TITLE
Enable Time-In-Range calculation in TherapyMetricsCard

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/cards/TherapyMetricsCard.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/components/cards/TherapyMetricsCard.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.jwoglom.controlx2.LocalDataStore
 import com.jwoglom.controlx2.db.historylog.HistoryLogViewModel
+import com.jwoglom.controlx2.presentation.screens.sections.components.CgmReadingHistoryLogs
+import com.jwoglom.controlx2.presentation.screens.sections.components.toCgmDataPoint
 import com.jwoglom.controlx2.presentation.theme.CardBackground
 import com.jwoglom.controlx2.presentation.theme.ControlX2Theme
 import com.jwoglom.controlx2.presentation.theme.Elevation
@@ -35,13 +37,6 @@ import com.jwoglom.controlx2.presentation.theme.InsulinColors
 import com.jwoglom.controlx2.presentation.theme.CarbColor
 import com.jwoglom.controlx2.presentation.theme.Spacing
 import com.jwoglom.controlx2.presentation.theme.SurfaceBackground
-import com.jwoglom.pumpx2.pump.messages.response.historyLog.BolusDeliveryHistoryLog
-import com.jwoglom.pumpx2.pump.messages.response.historyLog.DexcomG6CGMHistoryLog
-import com.jwoglom.pumpx2.pump.messages.response.historyLog.DexcomG7CGMHistoryLog
-import com.jwoglom.pumpx2.pump.messages.response.historyLog.CgmDataGxHistoryLog
-import java.time.Instant
-import java.time.ZoneId
-import kotlin.math.exp
 
 /**
  * Therapy Metrics Card displaying IOB
@@ -130,13 +125,12 @@ private fun MetricDisplay(
 
 
 /**
- * TherapyMetricsCard that automatically reads from the DataStore and calculates COB/TIR.
+ * TherapyMetricsCard that reads IOB from the DataStore and computes 24h Time-In-Range
+ * (70–180 mg/dL) from the CGM history log.
  */
 @Composable
 fun TherapyMetricsCardFromDataStore(
     historyLogViewModel: HistoryLogViewModel? = null,
-    showCOB: Boolean = false,
-    showTIR: Boolean = false,
     modifier: Modifier = Modifier
 ) {
     val ds = LocalDataStore.current
@@ -144,69 +138,23 @@ fun TherapyMetricsCardFromDataStore(
 
     val iob = iobUnits.value
 
-//    // Calculate TIR from CGM history (last 24 hours)
-//    val cgmHistoryLogs = historyLogViewModel?.latestItemsForTypes(
-//        listOf(
-//            DexcomG6CGMHistoryLog::class.java,
-//            DexcomG7CGMHistoryLog::class.java
-//        ),
-//        288 // ~24 hours of 5-min readings
-//    )?.observeAsState()
-//
-//    val timeInRange = remember(cgmHistoryLogs?.value) {
-//        cgmHistoryLogs?.value?.let { logs ->
-//            val validReadings = logs.mapNotNull { dao ->
-//                val parsed = dao.parse()
-//                when (parsed) {
-//                    is DexcomG6CGMHistoryLog -> parsed.currentGlucoseDisplayValue
-//                    is DexcomG7CGMHistoryLog -> parsed.currentGlucoseDisplayValue
-//                    is CgmDataGxHistoryLog -> parsed.value
-//                    else -> null
-//                }?.takeIf { it > 0 }
-//            }
-//            if (validReadings.isNotEmpty()) {
-//                val inRange = validReadings.count { it in 70..180 }
-//                (inRange.toFloat() / validReadings.size.toFloat()) * 100f
-//            } else null
-//        }
-//    }
-//
-//    // Calculate COB from carb history (carbs with exponential decay)
-//    val carbHistoryLogs = historyLogViewModel?.latestItemsForTypes(
-//        listOf(com.jwoglom.pumpx2.pump.messages.response.historyLog.CarbEnteredHistoryLog::class.java),
-//        50 // Last ~50 carb entries
-//    )?.observeAsState()
-//
-//    // TODO(jwoglom): THIS IS NOT READY YET
-//    val currentTimeSeconds = remember { Instant.now().epochSecond }
-//    val absorptionTimeSeconds = 180 * 60L // 3 hours
-//    val tau = absorptionTimeSeconds / 3.0
-//
-//    val cob = remember(carbHistoryLogs?.value, currentTimeSeconds) {
-//        carbHistoryLogs?.value?.let { logs ->
-//            var totalCob = 0f
-//            logs.forEach { dao ->
-//                val parsed = dao.parse()
-//                if (parsed is com.jwoglom.pumpx2.pump.messages.response.historyLog.CarbEnteredHistoryLog) {
-//                    val carbs = parsed.carbs.toInt()
-//                    if (carbs > 0) {
-//                        val timestamp = dao.pumpTime.atZone(ZoneId.systemDefault()).toEpochSecond()
-//                        val elapsedSeconds = currentTimeSeconds - timestamp
-//                        if (elapsedSeconds >= 0 && elapsedSeconds < absorptionTimeSeconds * 2) {
-//                            val remaining = carbs * exp(-elapsedSeconds / tau)
-//                            totalCob += remaining.toFloat()
-//                        }
-//                    }
-//                }
-//            }
-//            if (totalCob > 0.5f) totalCob else null
-//        }
-//    }
+    val cgmHistoryLogs = historyLogViewModel?.latestItemsForTypes(
+        CgmReadingHistoryLogs,
+        288 // ~24h at one reading per 5 minutes
+    )?.observeAsState()
+
+    val timeInRange = remember(cgmHistoryLogs?.value) {
+        cgmHistoryLogs?.value?.let { logs ->
+            val readings = logs.mapNotNull { it.toCgmDataPoint()?.value }
+            if (readings.isEmpty()) null
+            else readings.count { it in 70f..180f }.toFloat() / readings.size * 100f
+        }
+    }
 
     TherapyMetricsCard(
         iob = iob?.toFloat(),
         cob = null,
-        timeInRange = null,
+        timeInRange = timeInRange,
         modifier = modifier
     )
 }


### PR DESCRIPTION
## Summary
This PR enables the Time-In-Range (TIR) metric calculation in the TherapyMetricsCard component by implementing CGM history log reading and processing.

## Key Changes
- **Uncommented and refactored TIR calculation logic**: Activated the previously commented-out code that calculates 24-hour Time-In-Range (70–180 mg/dL) from CGM history logs
- **Simplified CGM data extraction**: Replaced inline type checking with new helper functions `CgmReadingHistoryLogs` and `toCgmDataPoint()` for cleaner code
- **Removed unused imports and code**: Cleaned up imports for unused history log types and removed incomplete COB (Carbs On Board) calculation code that was marked as "NOT READY YET"
- **Updated function documentation**: Clarified that `TherapyMetricsCardFromDataStore` now reads IOB from DataStore and computes 24h TIR from CGM history
- **Removed unused parameters**: Eliminated `showCOB` and `showTIR` boolean parameters that were not being utilized

## Implementation Details
- TIR is calculated by querying the last 288 CGM readings (~24 hours at 5-minute intervals)
- Valid glucose readings are extracted using the new `toCgmDataPoint()` helper function
- The percentage of readings within the 70–180 mg/dL range is computed and passed to the TherapyMetricsCard
- COB calculation remains disabled pending further development

https://claude.ai/code/session_011pBoh7DKJz78xNjzaACouH