### PR TITLE
Align wear app location permission with mobile

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -14,6 +14,15 @@
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <!--
+        Pre-S BLE scan requires fine location at runtime; coarse alone is
+        not sufficient on API <= 30 (BLUETOOTH_SCAN doesn't exist yet).
+        Scoped via maxSdkVersion so API 31+ relies on BLUETOOTH_SCAN. Declared
+        explicitly to cap the uncapped ACCESS_FINE_LOCATION that blessed-android
+        otherwise merges in at every SDK level.
+    -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
+        android:maxSdkVersion="30" />
 
     <uses-feature android:name="android.hardware.type.watch" />
 

--- a/wear/src/test/java/com/jwoglom/controlx2/ManifestPermissionsTest.kt
+++ b/wear/src/test/java/com/jwoglom/controlx2/ManifestPermissionsTest.kt
@@ -48,15 +48,18 @@ class ManifestPermissionsTest {
             "android.permission.ACCESS_COARSE_LOCATION",
             // Merged in by libraries at every SDK
             "android.permission.BLUETOOTH_ADVERTISE", // blessed-android
-            "android.permission.ACCESS_FINE_LOCATION", // blessed-android (no SDK cap)
             "com.google.android.wearable.permission.BIND_WATCH_FACE_CONTROL", // wear watchface
             "com.jwoglom.controlx2.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION", // androidx.core
         )
 
-        // Auto-stripped by the platform past API 30.
+        // Only present on API <= 30. BLUETOOTH and BLUETOOTH_ADMIN are
+        // auto-stripped by the platform past API 30; ACCESS_FINE_LOCATION
+        // is gated via android:maxSdkVersion="30" in our manifest (capping
+        // the otherwise-uncapped permission merged in by blessed-android).
         private val LEGACY_ONLY = setOf(
             "android.permission.BLUETOOTH",
             "android.permission.BLUETOOTH_ADMIN",
+            "android.permission.ACCESS_FINE_LOCATION",
         )
 
         private data class Case(val deviceSdk: Int, val expected: Set<String>)


### PR DESCRIPTION
The wear app declared only ACCESS_COARSE_LOCATION, so the uncapped ACCESS_FINE_LOCATION merged in by blessed-android flowed through to every SDK level — requesting precise location on API 31+ where BLE scanning relies on BLUETOOTH_SCAN and fine location is not needed.

Mirror the mobile module: declare ACCESS_FINE_LOCATION explicitly with android:maxSdkVersion="30" so the app-level cap overrides the library's uncapped contribution. Precise location is now requested only on API <= 30, where BLE scan requires it at runtime.

Update the wear ManifestPermissionsTest golden to move ACCESS_FINE_LOCATION from the always-present set into the legacy-only (<= 30) set accordingly.