### PR TITLE
Add Bolus and Temp Rate quick-action buttons to the service notification

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/CommService.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/CommService.kt
@@ -377,6 +377,9 @@ class CommService : Service(), CommServiceCallbacks {
                     Timber.i("apply-runtime-prefs: enabling onlySnoopBluetooth")
                     PumpState.onlySnoopBluetooth = true
                 }
+                // Rebuild the ongoing notification so toggled quick-action buttons
+                // (bolus / temp-rate, issue #152) appear or disappear immediately.
+                updateNotification()
             }
             MessagePaths.TO_SERVER_SERVICE_STATUS_ACKNOWLEDGED -> {
                 Timber.i("service-status acknowledged, stopping periodic sender")
@@ -869,7 +872,7 @@ class CommService : Service(), CommServiceCallbacks {
             contentText += "    \nConnection established at: ${shortTime(it)}"
         }
 
-        return builder
+        builder
             .setContentTitle(title)
             .setContentText(contentText)
             .setContentIntent(pendingIntent)
@@ -878,7 +881,40 @@ class CommService : Service(), CommServiceCallbacks {
             .setTicker(currentPumpData.statusText)
             .setPriority(NotificationCompat.PRIORITY_MAX) // for under android 26 compatibility
             .setOngoing(true)
-            .build()
+
+        // Optional quick-action buttons that deep-link into the bolus / temp-rate
+        // entry screens (issue #152). Each is gated by its own preference and reuses
+        // MainActivity's exported ACTION_OPEN_* deep links.
+        if (Prefs(applicationContext).showBolusNotificationButton()) {
+            builder.addAction(
+                R.drawable.bolus_icon, "Bolus",
+                openActivityAction(MainActivity.ACTION_OPEN_BOLUS, 2010)
+            )
+        }
+        if (Prefs(applicationContext).showTempRateNotificationButton()) {
+            builder.addAction(
+                R.drawable.bolus_icon_secondary, "Temp Rate",
+                openActivityAction(MainActivity.ACTION_OPEN_TEMP_RATE, 2011)
+            )
+        }
+
+        return builder.build()
+    }
+
+    /**
+     * Builds a PendingIntent that opens MainActivity for the given deep-link action
+     * (e.g. MainActivity.ACTION_OPEN_BOLUS). SINGLE_TOP ensures an already-foreground
+     * activity receives it via onNewIntent() instead of spawning a duplicate.
+     */
+    private fun openActivityAction(action: String, requestCode: Int): PendingIntent {
+        val intent = Intent(this, MainActivity::class.java).apply {
+            this.action = action
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+        }
+        return PendingIntent.getActivity(
+            this, requestCode, intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
     }
 
     private fun prefs(context: Context): SharedPreferences? {

--- a/mobile/src/main/java/com/jwoglom/controlx2/Prefs.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/Prefs.kt
@@ -133,6 +133,30 @@ class Prefs(val context: Context) {
     }
 
     /**
+     * Whether the ongoing service notification shows a "Bolus" quick-action button
+     * that deep-links into the bolus entry screen (issue #152).
+     */
+    fun showBolusNotificationButton(): Boolean {
+        return prefs().getBoolean("show-bolus-notification-button", true)
+    }
+
+    fun setShowBolusNotificationButton(b: Boolean) {
+        prefs().edit().putBoolean("show-bolus-notification-button", b).commit()
+    }
+
+    /**
+     * Whether the ongoing service notification shows a "Temp Rate" quick-action button
+     * that deep-links into the temp-rate entry screen (issue #152).
+     */
+    fun showTempRateNotificationButton(): Boolean {
+        return prefs().getBoolean("show-temp-rate-notification-button", true)
+    }
+
+    fun setShowTempRateNotificationButton(b: Boolean) {
+        prefs().edit().putBoolean("show-temp-rate-notification-button", b).commit()
+    }
+
+    /**
      * Sends basic application version telemetry to the server and enables automatic update checks.
      */
     fun checkForUpdates(): Boolean {

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Settings.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Settings.kt
@@ -232,6 +232,56 @@ fun Settings(
             }
 
             item {
+                var bolusButton by remember { mutableStateOf(Prefs(context).showBolusNotificationButton()) }
+                ListItem(
+                    headlineContent = { Text("Bolus button in notification") },
+                    supportingContent = {
+                        Text(
+                            if (bolusButton) "Shown. Tap to remove the Bolus shortcut from the ongoing notification."
+                            else "Hidden. Tap to add a Bolus shortcut to the ongoing notification."
+                        )
+                    },
+                    leadingContent = {
+                        Icon(
+                            if (bolusButton) Icons.Filled.NotificationsActive else Icons.Filled.Notifications,
+                            contentDescription = "Bolus notification button",
+                        )
+                    },
+                    modifier = Modifier.clickable {
+                        bolusButton = !bolusButton
+                        Prefs(context).setShowBolusNotificationButton(bolusButton)
+                        sendMessage(MessagePaths.TO_SERVER_APPLY_RUNTIME_PREFS, "".toByteArray())
+                    }
+                )
+                Divider()
+            }
+
+            item {
+                var tempRateButton by remember { mutableStateOf(Prefs(context).showTempRateNotificationButton()) }
+                ListItem(
+                    headlineContent = { Text("Temp rate button in notification") },
+                    supportingContent = {
+                        Text(
+                            if (tempRateButton) "Shown. Tap to remove the Temp Rate shortcut from the ongoing notification."
+                            else "Hidden. Tap to add a Temp Rate shortcut to the ongoing notification."
+                        )
+                    },
+                    leadingContent = {
+                        Icon(
+                            if (tempRateButton) Icons.Filled.NotificationsActive else Icons.Filled.Notifications,
+                            contentDescription = "Temp rate notification button",
+                        )
+                    },
+                    modifier = Modifier.clickable {
+                        tempRateButton = !tempRateButton
+                        Prefs(context).setShowTempRateNotificationButton(tempRateButton)
+                        sendMessage(MessagePaths.TO_SERVER_APPLY_RUNTIME_PREFS, "".toByteArray())
+                    }
+                )
+                Divider()
+            }
+
+            item {
                 ListItem(
                     headlineContent = { Text("Reconfigure pump") },
                     supportingContent = { Text("Disconnect and re-pair with a pump.") },


### PR DESCRIPTION
Adds optional "Bolus" and "Temp Rate" action buttons to the ongoing foreground-service notification (issue #152). Each button fires a PendingIntent that reuses MainActivity's existing exported ACTION_OPEN_BOLUS / ACTION_OPEN_TEMP_RATE deep links (the same navigation already used by the launcher long-press shortcuts), opening the corresponding bolus / temp-rate entry sheet.

Each button is gated by its own preference, both defaulting to on, with a toggle in Settings. Toggling sends TO_SERVER_APPLY_RUNTIME_PREFS so the ongoing notification rebuilds immediately.
