### PR TITLE
Fix xDrip bolus treatments: wrong timestamp and duplicate entries

### DIFF
--- a/db/src/main/java/com/jwoglom/controlx2/sync/xdrip/XdripMessageDispatcher.kt
+++ b/db/src/main/java/com/jwoglom/controlx2/sync/xdrip/XdripMessageDispatcher.kt
@@ -1,6 +1,7 @@
 package com.jwoglom.controlx2.sync.xdrip
 
 import android.content.Context
+import com.jwoglom.controlx2.shared.util.pumpTimeToLocalTz
 import com.jwoglom.controlx2.shared.util.twoDecimalPlaces
 import com.jwoglom.controlx2.sync.xdrip.models.XdripDeviceStatusSnapshot
 import com.jwoglom.controlx2.sync.xdrip.models.XdripSgvPayload
@@ -47,6 +48,12 @@ class XdripMessageDispatcher(
 
     private val latestPumpSnapshot = XdripDeviceStatusSnapshot()
 
+    // Tracks the last (bolusId, status) pair broadcast to xDrip so repeated
+    // CurrentBolusStatusResponse polls for the same in-flight bolus (e.g. multiple
+    // "DELIVERING" updates while it progresses) don't each create a separate xDrip
+    // treatment entry for what is really a single physical bolus.
+    private var lastBolusStatusBroadcast: Pair<Int, String>? = null
+
     fun onReceiveMessage(message: Message) {
         onEvent(message.toDispatchEvent())
     }
@@ -81,14 +88,22 @@ class XdripMessageDispatcher(
                     notes = "ControlX2 bolus initiated bolusId=${event.bolusId} status=${event.status}"
                 ).toJsonArrayString()
 
-                is DispatchEvent.TreatmentStatus -> XdripTreatmentPayload
-                    .fromStatus(
-                        bolusId = event.bolusId,
-                        requestedVolumeMilli = event.requestedVolumeMilli,
-                        status = event.status,
-                        timestamp = event.timestamp
-                    )
-                    .toJsonArrayString()
+                is DispatchEvent.TreatmentStatus -> {
+                    val statusKey = event.bolusId to event.status
+                    if (statusKey == lastBolusStatusBroadcast) {
+                        null
+                    } else {
+                        lastBolusStatusBroadcast = statusKey
+                        XdripTreatmentPayload
+                            .fromStatus(
+                                bolusId = event.bolusId,
+                                requestedVolumeMilli = event.requestedVolumeMilli,
+                                status = event.status,
+                                timestamp = event.timestamp
+                            )
+                            .toJsonArrayString()
+                    }
+                }
 
                 is DispatchEvent.BasalTreatment -> XdripTreatmentPayload
                     .forBasalRate(
@@ -166,7 +181,10 @@ class XdripMessageDispatcher(
                 bolusId = bolusId,
                 requestedVolumeMilli = requestedVolume,
                 status = status.toString(),
-                timestamp = timestampInstant
+                // timestampInstant is the pump's wall-clock reading encoded as if it were UTC
+                // (same "fake epoch" convention as HistoryLogItem.pumpTimeSec); correct it here
+                // or the xDrip treatment ends up shifted by the local UTC offset.
+                timestamp = pumpTimeToLocalTz(timestampInstant)
             )
             else -> DispatchEvent.Other
         }

--- a/db/src/main/java/com/jwoglom/controlx2/sync/xdrip/models/XdripTreatmentPayload.kt
+++ b/db/src/main/java/com/jwoglom/controlx2/sync/xdrip/models/XdripTreatmentPayload.kt
@@ -1,5 +1,6 @@
 package com.jwoglom.controlx2.sync.xdrip.models
 
+import com.jwoglom.controlx2.shared.util.pumpTimeToLocalTz
 import com.jwoglom.pumpx2.pump.messages.models.InsulinUnit
 import com.jwoglom.pumpx2.pump.messages.response.control.InitiateBolusResponse
 import com.jwoglom.pumpx2.pump.messages.response.currentStatus.CurrentBolusStatusResponse
@@ -45,10 +46,15 @@ data class XdripTreatmentPayload(
         }
 
         fun fromCurrentBolusStatusResponse(response: CurrentBolusStatusResponse): XdripTreatmentPayload {
+            // response.timestampInstant is the pump's wall-clock reading encoded as if it
+            // were UTC (same "fake epoch" convention as HistoryLogItem.pumpTimeSec) — it must
+            // be corrected via pumpTimeToLocalTz before use as a real UTC instant, or the
+            // uploaded treatment ends up shifted by the local UTC offset (e.g. an hour ahead).
+            val correctedInstant = pumpTimeToLocalTz(response.timestampInstant)
             return XdripTreatmentPayload(
                 eventType = "Bolus",
-                createdAt = response.timestampInstant.toString(),
-                mills = response.timestampInstant.toEpochMilli(),
+                createdAt = correctedInstant.toString(),
+                mills = correctedInstant.toEpochMilli(),
                 insulin = InsulinUnit.from1000To1(response.requestedVolume),
                 notes = "ControlX2 bolus status bolusId=${response.bolusId} status=${response.status}"
             )

--- a/db/src/test/java/com/jwoglom/controlx2/sync/xdrip/XdripMessageDispatcherTest.kt
+++ b/db/src/test/java/com/jwoglom/controlx2/sync/xdrip/XdripMessageDispatcherTest.kt
@@ -15,6 +15,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.time.Instant
+import java.util.TimeZone
 
 class XdripMessageDispatcherTest {
     private data class SentValue<T>(val payload: T, val minimumIntervalSeconds: Int?)
@@ -228,5 +229,88 @@ class XdripMessageDispatcherTest {
 
         assertEquals(1, broadcaster.sgvPayloads.size)
         assertEquals(15, broadcaster.sgvPayloads.single().minimumIntervalSeconds)
+    }
+
+    @Test
+    fun onReceiveMessage_repeatedIdenticalBolusStatusPolls_onlyBroadcastOnce() {
+        // Regression test for https://github.com/jwoglom/controlX2/issues/137:
+        // CurrentBolusStatusResponse is polled repeatedly while a bolus is DELIVERING.
+        // Each identical poll must not create a separate xDrip "Bolus" treatment.
+        val broadcaster = FakeBroadcaster()
+        val dispatcher = XdripMessageDispatcher(
+            broadcaster = broadcaster,
+            configProvider = {
+                XdripSyncConfig(
+                    enabled = true,
+                    sendCgmSgv = false,
+                    sendPumpDeviceStatus = false,
+                    sendStatusLine = false
+                )
+            },
+            nowProvider = { Instant.parse("2026-01-01T00:00:00Z") }
+        )
+
+        // statusId=1 -> DELIVERING, bolusId=77, polled three times with the same status.
+        dispatcher.onReceiveMessage(CurrentBolusStatusResponse(1, 77, 1710001234, 2300, 0, 0))
+        dispatcher.onReceiveMessage(CurrentBolusStatusResponse(1, 77, 1710001240, 2300, 0, 0))
+        dispatcher.onReceiveMessage(CurrentBolusStatusResponse(1, 77, 1710001250, 2300, 0, 0))
+
+        assertEquals(1, broadcaster.treatmentPayloads.size)
+
+        // statusId=0 -> ALREADY_DELIVERED_OR_INVALID: a real state transition, so it should
+        // still produce a second (final) broadcast.
+        dispatcher.onReceiveMessage(CurrentBolusStatusResponse(0, 77, 1710001260, 2300, 0, 0))
+        assertEquals(2, broadcaster.treatmentPayloads.size)
+
+        // A different bolusId is a distinct physical bolus and must always broadcast.
+        dispatcher.onReceiveMessage(CurrentBolusStatusResponse(1, 78, 1710001300, 1000, 0, 0))
+        assertEquals(3, broadcaster.treatmentPayloads.size)
+    }
+
+    @Test
+    fun onReceiveMessage_bolusStatusTimestamp_correctedForLocalUtcOffset() {
+        // Regression test for https://github.com/jwoglom/controlX2/issues/137:
+        // CurrentBolusStatusResponse.timestampInstant is the pump's wall-clock reading
+        // encoded as if it were UTC (Dates.fromJan12008EpochSecondsToDate), so it must be
+        // shifted by the local UTC offset before being uploaded to xDrip, or treatments
+        // show up shifted forward by that offset (e.g. an hour ahead in UTC+1/UTC+2).
+        val original = TimeZone.getDefault()
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("Europe/Berlin")) // always ahead of UTC
+            val offsetMillis = TimeZone.getDefault().getOffset(java.util.Date().time)
+            assertTrue("Test zone must be ahead of UTC for this assertion to be meaningful", offsetMillis > 0)
+
+            val broadcaster = FakeBroadcaster()
+            val dispatcher = XdripMessageDispatcher(
+                broadcaster = broadcaster,
+                configProvider = {
+                    XdripSyncConfig(
+                        enabled = true,
+                        sendCgmSgv = false,
+                        sendPumpDeviceStatus = false,
+                        sendStatusLine = false
+                    )
+                }
+            )
+
+            // pumpTimeSec=1710001234 encoded as fake-UTC: the pump's raw wall-clock reading,
+            // uncorrected for the local UTC offset.
+            val rawFakeUtcInstant = java.time.Instant.ofEpochSecond(1710001234L + 1199145600L)
+            dispatcher.onReceiveMessage(CurrentBolusStatusResponse(1, 90, 1710001234, 2300, 0, 0))
+
+            val status = JSONArray(broadcaster.treatmentPayloads.single().payload).getJSONObject(0)
+            val uploadedMills = status.getLong("mills")
+
+            assertTrue(
+                "Expected uploaded timestamp to be shifted earlier than the raw pump clock reading",
+                uploadedMills < rawFakeUtcInstant.toEpochMilli()
+            )
+            assertEquals(
+                rawFakeUtcInstant.toEpochMilli() - offsetMillis,
+                uploadedMills
+            )
+        } finally {
+            TimeZone.setDefault(original)
+        }
     }
 }


### PR DESCRIPTION
Fixes #137. Two related bugs in the live xDrip broadcast path (NightscoutSyncCoordinator's history-log-based sync is unaffected):

- CurrentBolusStatusResponse.timestampInstant encodes the pump's wall-clock reading as if it were UTC (same "fake epoch" convention as HistoryLogItem.pumpTimeSec), but XdripMessageDispatcher and XdripTreatmentPayload.fromCurrentBolusStatusResponse used it directly as a real UTC instant. This shifts every bolus status treatment forward by the local UTC offset (e.g. an hour ahead for UTC+1). The fix applies the same pumpTimeToLocalTz() correction already used for display of this exact field in MainActivity.

- CurrentBolusStatusResponse is polled repeatedly while a bolus is in flight, and every poll with an unchanged (bolusId, status) was broadcast to xDrip as a brand new "Bolus" treatment, since the broadcaster's cache only dedupes exact byte-identical payloads. XdripMessageDispatcher now tracks the last broadcast (bolusId, status) pair and only sends a new treatment when that pair actually changes, cutting the flood down to one broadcast per real state transition.

Added regression tests covering both symptoms.