### PR TITLE
Fix duplicate xDrip bolus treatments

### DIFF
--- a/db/src/main/java/com/jwoglom/controlx2/sync/xdrip/XdripMessageDispatcher.kt
+++ b/db/src/main/java/com/jwoglom/controlx2/sync/xdrip/XdripMessageDispatcher.kt
@@ -48,11 +48,17 @@ class XdripMessageDispatcher(
 
     private val latestPumpSnapshot = XdripDeviceStatusSnapshot()
 
-    // Tracks the last (bolusId, status) pair broadcast to xDrip so repeated
+    // Tracks the most recent real bolusId broadcast to xDrip so repeated
     // CurrentBolusStatusResponse polls for the same in-flight bolus (e.g. multiple
     // "DELIVERING" updates while it progresses) don't each create a separate xDrip
-    // treatment entry for what is really a single physical bolus.
-    private var lastBolusStatusBroadcast: Pair<Int, String>? = null
+    // treatment entry for what is really a single physical bolus. We can't wait for
+    // a terminal status: CurrentBolusStatusRequest polling is scoped to the bolus
+    // confirmation dialog's lifetime (BolusDialogs/BolusApprovedPhase) and commonly
+    // stops -- dialog dismissed, app backgrounded -- long before the pump reports a
+    // final state, so gating on completion silently drops the entry. requestedVolume
+    // is the bolus's *requested* amount (fixed at request time, not a running
+    // delivered-so-far tally), so the first poll already carries the right figure.
+    private var lastBroadcastBolusId: Int? = null
 
     fun onReceiveMessage(message: Message) {
         onEvent(message.toDispatchEvent())
@@ -81,6 +87,10 @@ class XdripMessageDispatcher(
 
         if (config.sendTreatments && StatusCategory.TREATMENT in categories) {
             val treatmentPayload = when (event) {
+                // No insulin/carbs on this payload -- xDrip (Treatments.noteOnly()) renders
+                // it as a distinct note-only graph marker, separate from the numeric dose
+                // marker the first status poll below produces. Not a duplicate dose entry,
+                // so unlike the repeated status polls, this is safe to keep sending as-is.
                 is DispatchEvent.TreatmentInitiated -> XdripTreatmentPayload(
                     eventType = "Bolus",
                     createdAt = receivedAt.toString(),
@@ -89,11 +99,13 @@ class XdripMessageDispatcher(
                 ).toJsonArrayString()
 
                 is DispatchEvent.TreatmentStatus -> {
-                    val statusKey = event.bolusId to event.status
-                    if (statusKey == lastBolusStatusBroadcast) {
+                    // bolusId=0 means "no active bolus" (see CurrentBolusStatusResponse.isValid())
+                    // -- both before any bolus starts and once the pump has fully reset after one
+                    // finishes. Only the first poll of a real, non-zero bolusId broadcasts.
+                    if (event.bolusId == 0 || event.bolusId == lastBroadcastBolusId) {
                         null
                     } else {
-                        lastBolusStatusBroadcast = statusKey
+                        lastBroadcastBolusId = event.bolusId
                         XdripTreatmentPayload
                             .fromStatus(
                                 bolusId = event.bolusId,

--- a/db/src/test/java/com/jwoglom/controlx2/sync/xdrip/XdripBroadcastIntegrationTest.kt
+++ b/db/src/test/java/com/jwoglom/controlx2/sync/xdrip/XdripBroadcastIntegrationTest.kt
@@ -159,11 +159,16 @@ class XdripBroadcastIntegrationTest {
     // ---------------------------------------------------------------
 
     @Test
-    fun fullPipeline_treatmentInitiatedBroadcast_matchesXdripSchema() {
+    fun fullPipeline_treatmentInitiatedBroadcast_isNoteOnlyNotDoseEntry() {
+        // InitiateBolusResponse broadcasts with no insulin/carbs field at all, so xDrip
+        // (Treatments.noteOnly(): carbs==0 && insulin==0 && notes present) renders it as a
+        // distinct note-only graph marker rather than a numeric dose marker -- it does not
+        // add a second dose to the count the first CurrentBolusStatusResponse poll produces
+        // (fullPipeline_treatmentStatusBroadcast_matchesXdripSchema), so keeping it doesn't
+        // reintroduce the duplicate-dose entries from #137.
         config = config.copy(sendCgmSgv = false, sendPumpDeviceStatus = false, sendStatusLine = false)
         dispatcher.onReceiveMessage(InitiateBolusResponse(0, 42, 0))
 
-        // xDrip receives both NEW_TREATMENT and NEW_FOOD
         val treatmentBroadcasts = broadcastsWithAction(XdripBroadcastSender.ACTION_NEW_TREATMENT)
         val foodBroadcasts = broadcastsWithAction(XdripBroadcastSender.ACTION_NEW_FOOD)
         assertEquals("one treatment broadcast", 1, treatmentBroadcasts.size)
@@ -172,22 +177,40 @@ class XdripBroadcastIntegrationTest {
         val bc = treatmentBroadcasts.single()
         assertEquals("treatments", bc.extraKey)
 
-        // xDrip parses: JSONArray(extras.getString("treatments")).getJSONObject(i)
         val arr = JSONArray(bc.payload)
         assertTrue("payload must be non-empty array", arr.length() > 0)
         val trtMap = jsonToMap(arr.getJSONObject(0).toString())
 
-        // xDrip reads mills or date: if neither is present, timestamp=0 → treatment rejected
         val mills = trtMap["mills"] ?: trtMap["date"]
         assertNotNull("xDrip reads 'mills'/'date' for timestamp — null causes rejection", mills)
         assertTrue("timestamp must be > 0 or treatment rejected", (mills as Number).toLong() > 0)
 
-        // xDrip reads eventType
         assertNotNull("eventType required", trtMap["eventType"])
         assertEquals("Bolus", trtMap["eventType"].toString())
 
-        // Food broadcast has same extra key
-        assertEquals("treatments", foodBroadcasts.single().extraKey)
+        // No insulin/carbs keys at all -- this is what makes it noteOnly() on the xDrip side.
+        assertTrue("must not carry an insulin field", !trtMap.containsKey("insulin"))
+        assertTrue("must not carry a carbs field", !trtMap.containsKey("carbs"))
+
+        // Notes present and identifying -- this is the marker's whole content.
+        assertNotNull("notes required for a note-only marker", trtMap["notes"])
+        assertTrue(trtMap["notes"].toString().contains("bolusId=42"))
+    }
+
+    @Test
+    fun fullPipeline_repeatedBolusStatusPolls_broadcastOnlyOnce() {
+        // CurrentBolusStatusRequest is polled repeatedly (up to once/second) while the bolus
+        // confirmation dialog is open (see BolusDialogs/BolusApprovedPhase) -- without this,
+        // every poll of the same in-flight bolus created a separate xDrip entry (see #137).
+        config = config.copy(sendCgmSgv = false, sendPumpDeviceStatus = false, sendStatusLine = false)
+
+        dispatcher.onReceiveMessage(CurrentBolusStatusResponse(2, 55, 1710001230, 1500, 0, 0)) // REQUESTING
+        nowMillis += 1000
+        dispatcher.onReceiveMessage(CurrentBolusStatusResponse(1, 55, 1710001234, 1500, 0, 0)) // DELIVERING
+        nowMillis += 1000
+        dispatcher.onReceiveMessage(CurrentBolusStatusResponse(1, 55, 1710001240, 1500, 0, 0)) // still DELIVERING
+
+        assertEquals("only the first poll broadcasts", 1, broadcastsWithAction(XdripBroadcastSender.ACTION_NEW_TREATMENT).size)
     }
 
     @Test
@@ -196,7 +219,7 @@ class XdripBroadcastIntegrationTest {
 
         // Send a status update (bolus in progress with insulin amount)
         nowMillis += 1000 // advance time to avoid dedup
-        dispatcher.onReceiveMessage(CurrentBolusStatusResponse(0, 77, 1710001234, 2300, 0, 0))
+        dispatcher.onReceiveMessage(CurrentBolusStatusResponse(2, 77, 1710001234, 2300, 0, 0))
 
         val treatmentBroadcasts = broadcastsWithAction(XdripBroadcastSender.ACTION_NEW_TREATMENT)
         assertEquals("one treatment broadcast", 1, treatmentBroadcasts.size)

--- a/db/src/test/java/com/jwoglom/controlx2/sync/xdrip/XdripMessageDispatcherTest.kt
+++ b/db/src/test/java/com/jwoglom/controlx2/sync/xdrip/XdripMessageDispatcherTest.kt
@@ -141,6 +141,10 @@ class XdripMessageDispatcherTest {
             nowProvider = { now }
         )
 
+        // InitiateBolusResponse still broadcasts (a note-only marker in xDrip, distinct from
+        // the numeric dose marker -- see XdripBroadcastIntegrationTest for the xDrip-side
+        // rendering distinction), and the first CurrentBolusStatusResponse for this bolusId
+        // broadcasts the actual dose. Two broadcasts total, not a duplicate dose entry.
         dispatcher.onReceiveMessage(InitiateBolusResponse(0, 77, 0))
         dispatcher.onReceiveMessage(CurrentBolusStatusResponse(0, 77, 1710001234, 2300, 0, 0))
 
@@ -232,10 +236,17 @@ class XdripMessageDispatcherTest {
     }
 
     @Test
-    fun onReceiveMessage_repeatedIdenticalBolusStatusPolls_onlyBroadcastOnce() {
+    fun onReceiveMessage_bolusLifecycle_broadcastsInitiationPlusOnceOnFirstStatusPoll() {
         // Regression test for https://github.com/jwoglom/controlX2/issues/137:
-        // CurrentBolusStatusResponse is polled repeatedly while a bolus is DELIVERING.
-        // Each identical poll must not create a separate xDrip "Bolus" treatment.
+        // a single physical bolus previously produced a growing pile of xDrip "Bolus"
+        // dose entries -- one per CurrentBolusStatusResponse poll, since polling repeats
+        // (often once/second) while the bolus confirmation dialog is open. Gating on the
+        // pump reaching a terminal status doesn't work either: that polling is scoped to
+        // the dialog's lifetime and commonly stops (dialog dismissed, app backgrounded)
+        // before a terminal status ever arrives, silently dropping the entry. Instead,
+        // only the *first* status poll for a given bolusId broadcasts a dose (requestedVolume
+        // is fixed at request time, already correct on that first poll). InitiateBolusResponse
+        // still broadcasts too, but as a no-insulin note-only marker, not a dose duplicate.
         val broadcaster = FakeBroadcaster()
         val dispatcher = XdripMessageDispatcher(
             broadcaster = broadcaster,
@@ -250,20 +261,29 @@ class XdripMessageDispatcherTest {
             nowProvider = { Instant.parse("2026-01-01T00:00:00Z") }
         )
 
-        // statusId=1 -> DELIVERING, bolusId=77, polled three times with the same status.
-        dispatcher.onReceiveMessage(CurrentBolusStatusResponse(1, 77, 1710001234, 2300, 0, 0))
-        dispatcher.onReceiveMessage(CurrentBolusStatusResponse(1, 77, 1710001240, 2300, 0, 0))
-        dispatcher.onReceiveMessage(CurrentBolusStatusResponse(1, 77, 1710001250, 2300, 0, 0))
-
+        dispatcher.onReceiveMessage(InitiateBolusResponse(0, 77, 0))
         assertEquals(1, broadcaster.treatmentPayloads.size)
 
-        // statusId=0 -> ALREADY_DELIVERED_OR_INVALID: a real state transition, so it should
-        // still produce a second (final) broadcast.
+        // statusId=2 -> REQUESTING: the first status poll, broadcasts the dose once.
+        dispatcher.onReceiveMessage(CurrentBolusStatusResponse(2, 77, 1710001230, 2300, 0, 0))
+        assertEquals(2, broadcaster.treatmentPayloads.size)
+
+        // Further polls for the same bolusId (still in flight, or eventually terminal)
+        // must not re-broadcast -- the dialog may never live long enough to see completion.
+        dispatcher.onReceiveMessage(CurrentBolusStatusResponse(1, 77, 1710001234, 2300, 0, 0))
+        dispatcher.onReceiveMessage(CurrentBolusStatusResponse(1, 77, 1710001240, 2300, 0, 0))
         dispatcher.onReceiveMessage(CurrentBolusStatusResponse(0, 77, 1710001260, 2300, 0, 0))
         assertEquals(2, broadcaster.treatmentPayloads.size)
 
-        // A different bolusId is a distinct physical bolus and must always broadcast.
-        dispatcher.onReceiveMessage(CurrentBolusStatusResponse(1, 78, 1710001300, 1000, 0, 0))
+        // bolusId=0 means "no active bolus" and must never broadcast a dose, whether seen
+        // before any bolus (idle) or after the pump resets once this one is fully done.
+        dispatcher.onReceiveMessage(CurrentBolusStatusResponse(0, 0, 1710001270, 0, 0, 0))
+        assertEquals(2, broadcaster.treatmentPayloads.size)
+
+        // A different bolusId is a distinct physical bolus and must broadcast its dose once.
+        dispatcher.onReceiveMessage(CurrentBolusStatusResponse(2, 78, 1710001300, 1000, 0, 0))
+        assertEquals(3, broadcaster.treatmentPayloads.size)
+        dispatcher.onReceiveMessage(CurrentBolusStatusResponse(1, 78, 1710001310, 1000, 0, 0))
         assertEquals(3, broadcaster.treatmentPayloads.size)
     }
 
@@ -294,9 +314,10 @@ class XdripMessageDispatcherTest {
             )
 
             // pumpTimeSec=1710001234 encoded as fake-UTC: the pump's raw wall-clock reading,
-            // uncorrected for the local UTC offset.
+            // uncorrected for the local UTC offset. This is the first status poll for
+            // bolusId=90, so it's the one that gets broadcast.
             val rawFakeUtcInstant = java.time.Instant.ofEpochSecond(1710001234L + 1199145600L)
-            dispatcher.onReceiveMessage(CurrentBolusStatusResponse(1, 90, 1710001234, 2300, 0, 0))
+            dispatcher.onReceiveMessage(CurrentBolusStatusResponse(2, 90, 1710001234, 2300, 0, 0))
 
             val status = JSONArray(broadcaster.treatmentPayloads.single().payload).getJSONObject(0)
             val uploadedMills = status.getLong("mills")


### PR DESCRIPTION
Follow-up to the earlier timestamp/duplicate fix on dev. Two issues turned up on real-device testing after that landed:

- CurrentBolusStatusRequest is polled repeatedly (often once/second) while the bolus confirmation dialog is open, and every poll of the same in-flight bolus was still creating its own xDrip dose entry -- the earlier fix only deduped exact repeats of an identical (bolusId, status) pair, not the distinct REQUESTING/DELIVERING/ terminal states a single bolus normally passes through.

- Gating the broadcast on the bolus reaching a terminal status doesn't work either: that polling is scoped to the confirmation dialog's lifetime and commonly stops (dialog dismissed, app backgrounded) before the pump ever reports a terminal state, so the entry silently never got sent at all.

requestedVolume on CurrentBolusStatusResponse is the bolus's requested amount, fixed at request time rather than a running delivered-so-far tally, so the first status poll already carries the correct figure. Now broadcasts once, on the first poll per bolusId, and ignores bolusId=0 (which means "no active bolus").

InitiateBolusResponse keeps broadcasting as before -- it carries no insulin/carbs field, so xDrip's own Treatments.noteOnly() renders it as a separate note-only graph marker rather than a dose entry, so it was never actually part of the duplicate-dose problem.

**Physical device end to end test result:**
<img  height="600" alt="image" src="https://github.com/user-attachments/assets/de28b42d-bdce-4660-8824-658793037802" />
