### PR TITLE
Add "Show glucose in notification" setting (BG + trend in ongoing notification)

### DIFF
--- a/mobile/src/main/java/com/jwoglom/controlx2/CommService.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/CommService.kt
@@ -42,7 +42,6 @@ import com.jwoglom.controlx2.util.HistoryLogFetcher
 import com.jwoglom.controlx2.util.HistoryLogSyncWorker
 import com.jwoglom.pumpx2.pump.TandemError
 import com.jwoglom.controlx2.shared.CommServiceCodes
-import com.jwoglom.controlx2.shared.FeatureFlag
 import com.jwoglom.controlx2.shared.FeatureFlags
 import com.jwoglom.controlx2.shared.InitiateConfirmedBolusSerializer
 import com.jwoglom.controlx2.shared.MessagePaths
@@ -665,14 +664,14 @@ class CommService : Service(), CommServiceCallbacks {
                 currentPumpData.cartridgeRemainingUnits = message.currentInsulinAmount
             }
             is CurrentEGVGuiDataResponse -> {
-                if (FeatureFlag.enabled(this, FeatureFlag.BGInNotification)) {
+                if (Prefs(applicationContext).showBGInNotification()) {
                     changed = currentPumpData.cgmReading != message.cgmReading
                 }
                 currentPumpData.cgmReading = message.cgmReading
             }
             is HomeScreenMirrorResponse -> {
                 val arrow = message.cgmTrendIcon.arrow()
-                if (FeatureFlag.enabled(this, FeatureFlag.BGInNotification)) {
+                if (Prefs(applicationContext).showBGInNotification()) {
                     changed = currentPumpData.cgmTrendArrow != arrow
                 }
                 currentPumpData.cgmTrendArrow = arrow
@@ -879,7 +878,7 @@ class CommService : Service(), CommServiceCallbacks {
         }
 
         var contentText = ""
-        if (FeatureFlag.enabled(this, FeatureFlag.BGInNotification) && currentPumpData.cgmReading != null) {
+        if (Prefs(applicationContext).showBGInNotification() && currentPumpData.cgmReading != null) {
             val glucoseUnit = Prefs(applicationContext).glucoseUnit() ?: GlucoseUnit.MGDL
             val bgText = GlucoseConverter.format(currentPumpData.cgmReading!!, glucoseUnit)
             val arrow = currentPumpData.cgmTrendArrow

--- a/mobile/src/main/java/com/jwoglom/controlx2/CommService.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/CommService.kt
@@ -42,6 +42,7 @@ import com.jwoglom.controlx2.util.HistoryLogFetcher
 import com.jwoglom.controlx2.util.HistoryLogSyncWorker
 import com.jwoglom.pumpx2.pump.TandemError
 import com.jwoglom.controlx2.shared.CommServiceCodes
+import com.jwoglom.controlx2.shared.FeatureFlag
 import com.jwoglom.controlx2.shared.FeatureFlags
 import com.jwoglom.controlx2.shared.InitiateConfirmedBolusSerializer
 import com.jwoglom.controlx2.shared.MessagePaths
@@ -49,6 +50,7 @@ import com.jwoglom.controlx2.shared.PumpMessageSerializer
 import com.jwoglom.controlx2.shared.messaging.MessageBus
 import com.jwoglom.controlx2.shared.messaging.MessageBusSender
 import com.jwoglom.controlx2.shared.messaging.MessageListener
+import com.jwoglom.controlx2.shared.util.GlucoseConverter
 import com.jwoglom.controlx2.shared.util.registerAppReloadShutdownHook
 import com.jwoglom.controlx2.shared.util.setupTimber
 import com.jwoglom.controlx2.shared.util.triggerAppReload
@@ -64,10 +66,14 @@ import com.jwoglom.pumpx2.pump.messages.models.KnownApiVersion
 import com.jwoglom.pumpx2.pump.messages.models.PairingCodeType
 import com.jwoglom.pumpx2.pump.messages.request.control.InitiateBolusRequest
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.ControlIQIOBRequest
+import com.jwoglom.pumpx2.pump.messages.request.currentStatus.CurrentEGVGuiDataRequest
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.HistoryLogStatusRequest
+import com.jwoglom.pumpx2.pump.messages.request.currentStatus.HomeScreenMirrorRequest
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.InsulinStatusRequest
 import com.jwoglom.pumpx2.pump.messages.response.currentStatus.ControlIQIOBResponse
 import com.jwoglom.pumpx2.pump.messages.response.currentStatus.CurrentBatteryAbstractResponse
+import com.jwoglom.pumpx2.pump.messages.response.currentStatus.CurrentEGVGuiDataResponse
+import com.jwoglom.pumpx2.pump.messages.response.currentStatus.HomeScreenMirrorResponse
 import com.jwoglom.pumpx2.pump.messages.response.currentStatus.InsulinStatusResponse
 import com.welie.blessed.BluetoothPeripheral
 import kotlinx.coroutines.CoroutineScope
@@ -169,6 +175,8 @@ class CommService : Service(), CommServiceCallbacks {
                 CurrentBatteryRequestBuilder.create(apiVersion()),
                 ControlIQIOBRequest(),
                 InsulinStatusRequest(),
+                CurrentEGVGuiDataRequest(),
+                HomeScreenMirrorRequest(),
                 HistoryLogStatusRequest()
             )))
         }
@@ -631,6 +639,8 @@ class CommService : Service(), CommServiceCallbacks {
         var batteryPercent: Int? = null,
         var iobUnits: Double? = null,
         var cartridgeRemainingUnits: Int? = null,
+        var cgmReading: Int? = null,
+        var cgmTrendArrow: String? = null,
     )
 
     private val currentPumpData: DisplayablePumpData = DisplayablePumpData()
@@ -653,6 +663,19 @@ class CommService : Service(), CommServiceCallbacks {
             is InsulinStatusResponse -> {
                 changed = currentPumpData.cartridgeRemainingUnits != message.currentInsulinAmount
                 currentPumpData.cartridgeRemainingUnits = message.currentInsulinAmount
+            }
+            is CurrentEGVGuiDataResponse -> {
+                if (FeatureFlag.enabled(this, FeatureFlag.BGInNotification)) {
+                    changed = currentPumpData.cgmReading != message.cgmReading
+                }
+                currentPumpData.cgmReading = message.cgmReading
+            }
+            is HomeScreenMirrorResponse -> {
+                val arrow = message.cgmTrendIcon.arrow()
+                if (FeatureFlag.enabled(this, FeatureFlag.BGInNotification)) {
+                    changed = currentPumpData.cgmTrendArrow != arrow
+                }
+                currentPumpData.cgmTrendArrow = arrow
             }
         }
 
@@ -856,6 +879,16 @@ class CommService : Service(), CommServiceCallbacks {
         }
 
         var contentText = ""
+        if (FeatureFlag.enabled(this, FeatureFlag.BGInNotification) && currentPumpData.cgmReading != null) {
+            val glucoseUnit = Prefs(applicationContext).glucoseUnit() ?: GlucoseUnit.MGDL
+            val bgText = GlucoseConverter.format(currentPumpData.cgmReading!!, glucoseUnit)
+            val arrow = currentPumpData.cgmTrendArrow
+            contentText += if (arrow.isNullOrEmpty()) {
+                "BG: $bgText\u00A0\u00A0\u00A0"
+            } else {
+                "BG: $bgText $arrow\u00A0\u00A0\u00A0"
+            }
+        }
         if (currentPumpData.batteryPercent != null) {
             contentText += "Battery: ${currentPumpData.batteryPercent}%\u00A0\u00A0\u00A0"
         }

--- a/mobile/src/main/java/com/jwoglom/controlx2/Prefs.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/Prefs.kt
@@ -66,6 +66,14 @@ class Prefs(val context: Context) {
         prefs().edit().putBoolean("connection-sharing-enabled", b).commit()
     }
 
+    fun showBGInNotification(): Boolean {
+        return prefs().getBoolean("show-bg-in-notification", false)
+    }
+
+    fun setShowBGInNotification(b: Boolean) {
+        prefs().edit().putBoolean("show-bg-in-notification", b).commit()
+    }
+
     fun onlySnoopBluetoothEnabled(): Boolean {
         return prefs().getBoolean("only-snoop-bluetooth-enabled", false)
     }

--- a/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Settings.kt
+++ b/mobile/src/main/java/com/jwoglom/controlx2/presentation/screens/sections/Settings.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -307,6 +308,42 @@ fun Settings(
                     )
                     Divider()
                 }
+            }
+
+            item {
+                HeaderLine("Notifications")
+                Divider()
+            }
+
+            item {
+                var showBGInNotification by remember { mutableStateOf(Prefs(context).showBGInNotification()) }
+                fun applyShowBGInNotification(checked: Boolean) {
+                    showBGInNotification = checked
+                    Prefs(context).setShowBGInNotification(checked)
+                    coroutineScope.launch {
+                        delay(250)
+                        // Reload the service so the ongoing notification is rebuilt with the new setting.
+                        sendMessage(MessagePaths.TO_SERVER_FORCE_RELOAD, "".toByteArray())
+                    }
+                }
+                ListItem(
+                    headlineContent = { Text("Show glucose in notification") },
+                    supportingContent = { Text("Include the latest CGM reading and trend arrow in the ongoing ControlX2 notification.") },
+                    leadingContent = {
+                        Icon(
+                            Icons.Filled.Notifications,
+                            contentDescription = null,
+                        )
+                    },
+                    trailingContent = {
+                        Switch(
+                            checked = showBGInNotification,
+                            onCheckedChange = { applyShowBGInNotification(it) },
+                        )
+                    },
+                    modifier = Modifier.clickable { applyShowBGInNotification(!showBGInNotification) }
+                )
+                Divider()
             }
 
             item {

--- a/mobile/src/test/java/com/jwoglom/controlx2/CommServiceIntegrationTest.kt
+++ b/mobile/src/test/java/com/jwoglom/controlx2/CommServiceIntegrationTest.kt
@@ -7,7 +7,6 @@ import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.jwoglom.controlx2.messaging.MessageBusFactory
-import com.jwoglom.controlx2.shared.FeatureFlag
 import com.jwoglom.controlx2.shared.InitiateConfirmedBolusSerializer
 import com.jwoglom.controlx2.shared.MessagePaths
 import com.jwoglom.controlx2.shared.PumpMessageSerializer
@@ -766,8 +765,8 @@ class CommServiceIntegrationTest {
     }
 
     @Test
-    fun connectedPump_cgmResponse_withBGInNotificationFlag_showsBgInNotification() {
-        FeatureFlag.set(context, FeatureFlag.BGInNotification, true)
+    fun connectedPump_cgmResponse_withShowBGInNotificationPref_showsBgInNotification() {
+        Prefs(context).setShowBGInNotification(true)
         startServiceAndConnectPump()
 
         val response = CurrentEGVGuiDataResponse(1710000000, 123, 1, 2)
@@ -783,8 +782,8 @@ class CommServiceIntegrationTest {
     }
 
     @Test
-    fun connectedPump_cgmResponse_withoutBGInNotificationFlag_omitsBgFromNotification() {
-        // BGInNotification defaults to off; do not enable it.
+    fun connectedPump_cgmResponse_withoutShowBGInNotificationPref_omitsBgFromNotification() {
+        // showBGInNotification defaults to off; do not enable it.
         startServiceAndConnectPump()
 
         val response = CurrentEGVGuiDataResponse(1710000000, 123, 1, 2)

--- a/mobile/src/test/java/com/jwoglom/controlx2/CommServiceIntegrationTest.kt
+++ b/mobile/src/test/java/com/jwoglom/controlx2/CommServiceIntegrationTest.kt
@@ -1,11 +1,13 @@
 package com.jwoglom.controlx2
 
+import android.app.Notification
 import android.content.Context
 import android.content.SharedPreferences
 import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.jwoglom.controlx2.messaging.MessageBusFactory
+import com.jwoglom.controlx2.shared.FeatureFlag
 import com.jwoglom.controlx2.shared.InitiateConfirmedBolusSerializer
 import com.jwoglom.controlx2.shared.MessagePaths
 import com.jwoglom.controlx2.shared.PumpMessageSerializer
@@ -752,6 +754,47 @@ class CommServiceIntegrationTest {
         assertTrue(
             "CGM response should be forwarded to wear",
             messageBus.hasMessage(MessagePaths.TO_CLIENT_SERVICE_RECEIVE_MESSAGE)
+        )
+    }
+
+    /**
+     * Read the content text of the most recently posted foreground notification.
+     */
+    private fun lastNotificationText(): String? {
+        val notification = shadowOf(service).lastForegroundNotification ?: return null
+        return notification.extras?.getCharSequence(Notification.EXTRA_TEXT)?.toString()
+    }
+
+    @Test
+    fun connectedPump_cgmResponse_withBGInNotificationFlag_showsBgInNotification() {
+        FeatureFlag.set(context, FeatureFlag.BGInNotification, true)
+        startServiceAndConnectPump()
+
+        val response = CurrentEGVGuiDataResponse(1710000000, 123, 1, 2)
+        capturedPump!!.onReceiveMessage(mockPeripheral, response)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        val text = lastNotificationText()
+        assertNotNull("Foreground notification should be present", text)
+        assertTrue(
+            "Notification should include BG reading when flag is enabled (was: $text)",
+            text!!.contains("BG: 123")
+        )
+    }
+
+    @Test
+    fun connectedPump_cgmResponse_withoutBGInNotificationFlag_omitsBgFromNotification() {
+        // BGInNotification defaults to off; do not enable it.
+        startServiceAndConnectPump()
+
+        val response = CurrentEGVGuiDataResponse(1710000000, 123, 1, 2)
+        capturedPump!!.onReceiveMessage(mockPeripheral, response)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        val text = lastNotificationText()
+        assertFalse(
+            "Notification should not include BG when flag is disabled (was: $text)",
+            text?.contains("BG:") ?: false
         )
     }
 

--- a/shared/src/main/java/com/jwoglom/controlx2/shared/FeatureFlag.kt
+++ b/shared/src/main/java/com/jwoglom/controlx2/shared/FeatureFlag.kt
@@ -14,7 +14,6 @@ import android.content.Context
  */
 enum class FeatureFlag {
     BTHostSwitch,
-    BGInNotification,
     ;
 
     val slug: String get() = name

--- a/shared/src/main/java/com/jwoglom/controlx2/shared/FeatureFlag.kt
+++ b/shared/src/main/java/com/jwoglom/controlx2/shared/FeatureFlag.kt
@@ -14,6 +14,7 @@ import android.content.Context
  */
 enum class FeatureFlag {
     BTHostSwitch,
+    BGInNotification,
     ;
 
     val slug: String get() = name


### PR DESCRIPTION
Adds an opt-in **Show glucose in notification** preference under **Settings → Notifications** that shows the latest CGM reading and trend arrow in ControlX2's ongoing foreground notification, alongside the existing Battery / IOB / Cartridge values. Off by default.

Closes #20.

## Changes
- **Settings → Notifications**: new section with a "Show glucose in notification" toggle.
- **Prefs**: `showBGInNotification()` / `setShowBGInNotification()` (key `show-bg-in-notification`, default off).
- **CommService**: captures the CGM reading (`CurrentEGVGuiDataResponse`) and trend arrow (`HomeScreenMirrorResponse`) and renders the reading with its arrow (e.g. `BG: 120 ↗`) in the notification when the setting is enabled. Values respect the existing mg/dL / mmol/L unit preference. The 5-minute periodic refresh now also requests CGM + home-screen-mirror data so the reading stays current when no screen is open.
- Toggling the setting reloads the service so the notification reflects the change immediately.

## Testing
- `:mobile:testDebugUnitTest` — added two `CommServiceIntegrationTest` cases (setting on → BG shown; off → BG omitted). 40/40 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzUYVByFtYjSkMBod5MwTR